### PR TITLE
Node.replaceChildAtIdx doesn't work with cloning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ grunt.initConfig({
   watch: {
     scripts: {
       files: ['**/*.js', 'test.es6'],
-      tasks: ['babel'],
+      tasks: ['default'],
       options: {
         spawn: false,
       },

--- a/test/sandbox.html
+++ b/test/sandbox.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div id="input">
-      <textarea id="template" placeholder="Template goes here">&lt;p&gt;{?name}Hello, {name}{:else}Welcome, guest{/name}&lt;/p&gt;</textarea>
+      <textarea id="template" placeholder="Template goes here">&lt;div&gt;&lt;ul&gt;&lt;li&gt;&lt;p&gt;Some text &lt;span&gt;with&lt;/span&gt; some other text. &lt;button&gt;Click &lt;b&gt;me&lt;/b&gt;&lt;/button&gt;&lt;/p&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;</textarea>
       <textarea id="context" placeholder="Context goes here">{
   name: "Ruby"
 }</textarea>


### PR DESCRIPTION
We need to be able to cache fragments and clone them, and therefore we
cannot cache the elements that contain references as direct children.
Instead we will have to create a td runtime method that takes an element
(the base fragment) and an array of indexes that will dictate where the
insertion should happen.

The array of indexes is working correctly now.
