### PR TITLE
Improve how promises are handled in get chains

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -50,11 +50,12 @@ let tornado = {
     newContext = context[path.shift()];
     if (this.util.isFunction(newContext)) {
       newContext = newContext.bind(context)();
-      if (this.util.isPromise(newContext)) {
-        return newContext.then(val => this.get(val, path));
-      }
-      // If newContext is not a promise, it will pass through to the next if statement
     }
+
+    if (this.util.isPromise(newContext)) {
+      return newContext.then(val => this.get(val, path));
+    }
+
     if (this.util.isObject(newContext)) {
       return this.get(newContext, path);
     }

--- a/test/acceptance/section.js
+++ b/test/acceptance/section.js
@@ -206,6 +206,21 @@ let suite = {
       })()
     },
     {
+      description: 'Section with dotted reference where first part is a promise',
+      template: 'Hello, {#right.now}later{/right.now}',
+      context: {
+        right: new Promise((resolve, reject) => {
+          resolve({now: true});
+        })
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('Hello, '));
+        frag.appendChild(document.createTextNode('later'));
+        return frag;
+      })()
+    },
+    {
       description: 'Section with sibling exists',
       template: '<div>{#brother}brother{/brother}</div><div>{#sister} and sister{/sister}</div>',
       context: {

--- a/test/sandbox/index.html
+++ b/test/sandbox/index.html
@@ -5,15 +5,21 @@
   </head>
   <body>
     <div id="input">
-      <textarea id="template" placeholder="Template goes here"><p>Hello, {#names}{name}{/names}</p></textarea>
+      <textarea id="template" placeholder="Template goes here"><h3>What's on reddit:</h3>
+<ul>
+  {#reddit.data.children}
+    <li>
+      {#data.thumbnail}
+        <img src="{.}">
+      {/data.thumbnail}
+      <p>{data.author}</p>
+      <a href="{data.url}">{data.title}</a>
+    </li>
+  {/reddit.data.children}
+</ul></textarea>
       <textarea id="context" placeholder="Context goes here">{
-  names: new Promise(function(resolve, reject) {
-    setTimeout(function() {
-      resolve([
-        {name: "Ruby"},
-        {name: "Toto"}
-      ]);
-    }, 1000)
+  reddit: fetch('http://www.reddit.com/.json?limit=10').then(function(res) {
+  return res.json();
   })
 }</textarea>
       <button id="render">Render</button>


### PR DESCRIPTION
Before, only a function that returned a promise would handle the promise
correctly. Now, a promise can be used directly.
