### PR TITLE
Don't cache HTML, cache node refs instead

### DIFF
--- a/dist/compiler/passes/generateJS.js
+++ b/dist/compiler/passes/generateJS.js
@@ -15,15 +15,13 @@ var noop = function noop() {};
 
 var codeGenerator = generator.build({
   insert_TORNADO_PARTIAL: function insert_TORNADO_PARTIAL(instruction, code) {
-    var indexPath = instruction.indexPath;
     var tdBody = instruction.tdBody;
     var key = instruction.key;
 
     var context = "c";
-    var indexHash = indexPath.join("");
     if (instruction.state !== STATES.HTML_ATTRIBUTE) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n      td." + util.getTdMethodName("replaceNode") + "(p" + indexHash + ", td." + util.getTdMethodName("getPartial") + "('" + key + "', " + context + ", this));\n";
+      var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("getPartial") + "('" + key + "', " + context + ", this));\n";
       code.push(tdBody, { fragment: fragment, renderer: renderer });
     } else {
       var renderer = "td." + util.getTdMethodName("getPartial") + "('" + key + "', " + context + ", this).then(function(node){return td." + util.getTdMethodName("nodeToString") + "(node)}),";
@@ -54,13 +52,11 @@ var codeGenerator = generator.build({
   insert_TORNADO_REFERENCE: function insert_TORNADO_REFERENCE(instruction, code) {
     var tdBody = instruction.tdBody;
     var key = instruction.key;
-    var indexPath = instruction.indexPath;
     var state = instruction.state;
 
-    var indexHash = indexPath.join("");
     if (state !== STATES.HTML_ATTRIBUTE) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n        td." + util.getTdMethodName("replaceNode") + "(p" + indexHash + ", td." + util.getTdMethodName("createTextNode") + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + ")));\n";
+      var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("createTextNode") + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + ")));\n";
       code.push(tdBody, { fragment: fragment, renderer: renderer });
     } else {
       var renderer = "td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "),";
@@ -97,19 +93,21 @@ var codeGenerator = generator.build({
   },
   open_HTML_ATTRIBUTE: function open_HTML_ATTRIBUTE(instruction, code) {
     var tdBody = instruction.tdBody;
-    var indexPath = instruction.indexPath;
     var node = instruction.node;
     var hasTornadoRef = instruction.hasTornadoRef;
+    var parentNodeName = instruction.parentNodeName;
 
     var attrInfo = node[1];
+    var placeholderName = this.getPlaceholderName(instruction);
+    var fragment = "      res." + placeholderName + " = " + parentNodeName + ";\n";
     var renderer = "      td." + util.getTdMethodName("setAttribute");
-    renderer += "(td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + "), '" + attrInfo.attrName + "', ";
+    renderer += "(root." + placeholderName + ", '" + attrInfo.attrName + "', ";
     if (hasTornadoRef) {
       renderer += "[";
     } else {
       renderer += "";
     }
-    code.push(tdBody, { renderer: renderer });
+    code.push(tdBody, { fragment: fragment, renderer: renderer });
   },
   close_HTML_ATTRIBUTE: function close_HTML_ATTRIBUTE(instruction, code) {
     var tdBody = instruction.tdBody;
@@ -142,37 +140,41 @@ var codeGenerator = generator.build({
 
   createMethodHeaders: function createMethodHeaders(tdBody, code, methodName) {
     var suffix = methodName ? methodName : tdBody;
-    var fragment = "f" + suffix + ": function() {\n      var frag = td." + util.getTdMethodName("createDocumentFragment") + "();\n";
-    var renderer = "r" + suffix + ": function(c) {\n      var root = frags.frag" + suffix + " || this.f" + suffix + "();\n      root = root.cloneNode(true);\n";
+    var fragment = "f" + suffix + ": function() {\n      var res = {};\n      var frag = td." + util.getTdMethodName("createDocumentFragment") + "();\n      res.frag = frag;\n";
+    var renderer = "r" + suffix + ": function(c) {\n      var root = this.f" + suffix + "();\n";
     code.push(tdBody, { fragment: fragment, renderer: renderer });
   },
 
-  createMethodFooters: function createMethodFooters(tdBody, code, methodName) {
-    var suffix = methodName ? methodName : tdBody;
-    var fragment = "      frags.frag" + suffix + " = frag;\n      return frag;\n    }";
-    var renderer = "      return root;\n    }";
+  createMethodFooters: function createMethodFooters(tdBody, code) {
+    var fragment = "      return res;\n    }";
+    var renderer = "      return root.frag;\n    }";
     code.push(tdBody, { fragment: fragment, renderer: renderer });
   },
 
   createPlaceholder: function createPlaceholder(instruction) {
-    return "" + instruction.parentNodeName + ".appendChild(td." + util.getTdMethodName("createTextNode") + "(''))";
+    var placeholderName = this.getPlaceholderName(instruction);
+    return "var " + placeholderName + " = td." + util.getTdMethodName("createTextNode") + "('');\n      " + instruction.parentNodeName + ".appendChild(" + placeholderName + ");\n      res." + placeholderName + " = " + placeholderName + ";";
+  },
+
+  getPlaceholderName: function getPlaceholderName(instruction) {
+    var indexPath = instruction.indexPath;
+
+    return "p" + indexPath.join("");
   },
 
   tdBody_exists: function tdBody_exists(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var indexPath = instruction.indexPath;
     var state = instruction.state;
     var key = instruction.key;
     var node = instruction.node;
     var bodyType = instruction.bodyType;
 
-    var indexHash = indexPath.join("");
     var bodies = node[1].bodies;
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
     if (state !== STATES.HTML_ATTRIBUTE) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n      td." + util.getTdMethodName(bodyType) + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), p" + indexHash + ", " + bodiesHash + ", c);\n";
+      var renderer = "      td." + util.getTdMethodName(bodyType) + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), root." + this.getPlaceholderName(instruction) + ", " + bodiesHash + ", c);\n";
       code.push(parentTdBody, { renderer: renderer, fragment: fragment });
     } else {
       var renderer = "td." + util.getTdMethodName(bodyType) + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), null, " + bodiesHash + ", c),";
@@ -187,16 +189,14 @@ var codeGenerator = generator.build({
   tdBody_section: function tdBody_section(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var indexPath = instruction.indexPath;
     var state = instruction.state;
     var key = instruction.key;
     var node = instruction.node;
 
-    var indexHash = indexPath.join("");
     var bodies = node[1].bodies;
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
     var isInHtmlAttribute = state === STATES.HTML_ATTRIBUTE;
-    var placeholderNode = isInHtmlAttribute ? "null" : "p" + indexHash;
+    var placeholderNode = isInHtmlAttribute ? "null" : "root." + this.getPlaceholderName(instruction);
 
     var output = "td." + util.getTdMethodName("section") + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), " + placeholderNode + ", " + bodiesHash + ", c)";
 
@@ -205,23 +205,21 @@ var codeGenerator = generator.build({
       code.push(parentTdBody, { renderer: renderer });
     } else {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n      " + output + ";\n";
+      var renderer = "      " + output + ";\n";
       code.push(parentTdBody, { fragment: fragment, renderer: renderer });
     }
   },
 
   tdBody_block: function tdBody_block(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
-    var indexPath = instruction.indexPath;
     var state = instruction.state;
     var key = instruction.key;
     var blockIndex = instruction.blockIndex;
 
-    var indexHash = indexPath.join("");
     var blockName = key.join(".");
     if (state !== STATES.HTML_ATTRIBUTE) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n      td." + util.getTdMethodName("replaceNode") + "(p" + indexHash + ", td." + util.getTdMethodName("block") + "('" + blockName + "', " + blockIndex + ", c, this));\n";
+      var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("block") + "('" + blockName + "', " + blockIndex + ", c, this));\n";
       code.push(parentTdBody, { fragment: fragment, renderer: renderer });
     } else {
       var renderer = "td." + util.getTdMethodName("nodeToString") + "(td." + util.getTdMethodName("block") + "('" + blockName + "', " + blockIndex + ", c, this)),";
@@ -232,19 +230,17 @@ var codeGenerator = generator.build({
   tdBody_helper: function tdBody_helper(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var indexPath = instruction.indexPath;
     var state = instruction.state;
     var key = instruction.key;
     var node = instruction.node;
 
-    var indexHash = indexPath.join("");
     var params = node[1].params;
     var bodies = node[1].bodies;
     var paramsHash = this.createParamsHash(params);
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
     if (state !== STATES.HTML_ATTRIBUTE) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
-      var renderer = "      var p" + indexHash + " = td." + util.getTdMethodName("getNodeAtIdxPath") + "(root, " + JSON.stringify(indexPath) + ");\n      td." + util.getTdMethodName("helper") + "('" + key.join(".") + "', p" + indexHash + ", c, " + paramsHash + ", " + bodiesHash + ");\n";
+      var renderer = "      td." + util.getTdMethodName("helper") + "('" + key.join(".") + "', root." + this.getPlaceholderName(instruction) + ", c, " + paramsHash + ", " + bodiesHash + ");\n";
       code.push(parentTdBody, { fragment: fragment, renderer: renderer });
     }
   },

--- a/dist/runtime.js
+++ b/dist/runtime.js
@@ -362,7 +362,7 @@ var tornado = {
       frag.appendChild(document.createTextNode(""));
       return frag;
     }
-    return renderer(context);
+    return renderer(context).frag;
   },
 
   getBlockRenderer: function getBlockRenderer(name, idx, template) {
@@ -383,33 +383,6 @@ var tornado = {
       template = template.parentTemplate;
     }
     // If no renderer is found, undefined will be returned.
-  },
-
-  /**
-   * Within a given HTML node, find the node at the given index path.
-   * for more details.
-   * @param {HTMLNode} root The parent node
-   * @param {Array} indexPath The path of indexes to the node being searched for.
-   * @param {HTMLNode|Boolean} The HTML Node if it is found, or `false`
-   */
-  getNodeAtIdxPath: function getNodeAtIdxPath(root, indexPath) {
-    var nextIdx = undefined;
-
-    if (indexPath.length === 0) {
-      return root;
-    }
-
-    // Make sure we are dealing with an HTML element
-    var intermediateNode = root.childNodes ? root : false;
-    while (intermediateNode && indexPath.length) {
-      if (intermediateNode.childNodes) {
-        nextIdx = indexPath.shift();
-        intermediateNode = intermediateNode.childNodes[nextIdx];
-      } else {
-        return false;
-      }
-    }
-    return intermediateNode || false;
   },
 
   /**
@@ -603,7 +576,6 @@ tornado.n = tornado.replaceNode;
 tornado.e = tornado.exists;
 tornado.h = tornado.helper;
 tornado.b = tornado.block;
-tornado.i = tornado.getNodeAtIdxPath;
 tornado.t = tornado.nodeToString;
 
 module.exports = tornado;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -335,7 +335,7 @@ let tornado = {
       frag.appendChild(document.createTextNode(''));
       return frag;
     }
-    return renderer(context);
+    return renderer(context).frag;
   },
 
   getBlockRenderer(name, idx, template) {
@@ -356,33 +356,6 @@ let tornado = {
       template = template.parentTemplate;
     }
     // If no renderer is found, undefined will be returned.
-  },
-
-  /**
-   * Within a given HTML node, find the node at the given index path.
-   * for more details.
-   * @param {HTMLNode} root The parent node
-   * @param {Array} indexPath The path of indexes to the node being searched for.
-   * @param {HTMLNode|Boolean} The HTML Node if it is found, or `false`
-   */
-  getNodeAtIdxPath(root, indexPath) {
-    let nextIdx;
-
-    if (indexPath.length === 0) {
-      return root;
-    }
-
-    // Make sure we are dealing with an HTML element
-    let intermediateNode = root.childNodes ? root : false;
-    while (intermediateNode && indexPath.length) {
-      if (intermediateNode.childNodes) {
-        nextIdx = indexPath.shift();
-        intermediateNode = intermediateNode.childNodes[nextIdx];
-      } else {
-        return false;
-      }
-    }
-    return intermediateNode || false;
   },
 
   /**
@@ -565,7 +538,6 @@ tornado.n = tornado.replaceNode;
 tornado.e = tornado.exists;
 tornado.h = tornado.helper;
 tornado.b = tornado.block;
-tornado.i = tornado.getNodeAtIdxPath;
 tornado.t = tornado.nodeToString;
 
 export default tornado;

--- a/test/acceptance/exists.js
+++ b/test/acceptance/exists.js
@@ -132,6 +132,23 @@ let suite = {
       })()
     },
     {
+      description: 'Exists containing multiple HTML elements, followd by refernece',
+      template: 'Hello, {?name}<span>world</span>.{/name} My name is {name}.',
+      context: {name: 'Dorothy'},
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('Hello, '));
+        let span = document.createElement('span');
+        span.appendChild(document.createTextNode('world'));
+        frag.appendChild(span);
+        frag.appendChild(document.createTextNode('.'));
+        frag.appendChild(document.createTextNode(' My name is '));
+        frag.appendChild(document.createTextNode('Dorothy'));
+        frag.appendChild(document.createTextNode('.'));
+        return frag;
+      })()
+    },
+    {
       description: 'Exists with else where reference is falsy',
       template: 'Hello, {?name}world{:else}abyss{/name}',
       context: {name: false},


### PR DESCRIPTION
Because we are cloning nodes, we can't cache references to dom nodes.
Instead, we have to do a lookup to find the nodes at render time. This
commit enables us to cache the dom nodes that will be replaced by
dynamic values, and eliminates the need for the lookup.

This fixes a bug where node lookups are incorrect if previously inserted
dynamic values include multiple nodes. The hope is that the performance
lost from having to rebuild the HTML for each render will be offset (and
perhaps outweighed) by not having to do the index path lookups and by
not having to clone document fragments.
