### PR TITLE
Update description of HTML Attribute/comment test

### DIFF
--- a/test/acceptance/html.js
+++ b/test/acceptance/html.js
@@ -46,7 +46,7 @@ let suite = {
       })()
     },
     {
-      description: 'HTML comment within HTML attribute',
+      description: 'HTML attribute whose value contains characters that look like an HTML comment',
       template: '<div class="<!-- comment -->"></div>',
       context: {},
       expectedDom: (() => {


### PR DESCRIPTION
Characters inside an attribute value that look like an HTML comment are not actually an HTML comment, they are just characters.
