### PR TITLE
Add a node interface for Tornado

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,8 @@ grunt.initConfig({
       },
       files: [
         {expand: true, cwd: 'src/', dest: 'dist/', ext: '.js', src: '**/*.js'},
-        {src: 'bin/tornado.es6', dest: 'bin/tornado'}
+        {src: 'bin/tornado.es6', dest: 'bin/tornado'},
+        {src: 'index.es6', dest: 'tornado.js'}
       ]
     },
     acceptance: {

--- a/index.es6
+++ b/index.es6
@@ -1,0 +1,10 @@
+import parser from './dist/parser';
+import compiler from './src/compiler';
+
+let tornado = {
+  compile(templateString, name, options) {
+    return compiler.compile(parser.parse(templateString), name, options);
+  }
+};
+
+export default tornado;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tornado.js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "\"Asynchronous HTML templating\"",
   "main": "tornado.js",
   "scripts": {

--- a/tornado.js
+++ b/tornado.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var parser = _interopRequire(require("./dist/parser"));
+
+var compiler = _interopRequire(require("./src/compiler"));
+
+var tornado = {
+  compile: function compile(templateString, name, options) {
+    return compiler.compile(parser.parse(templateString), name, options);
+  }
+};
+
+module.exports = tornado;
+//# sourceMappingURL=tornado.js.map


### PR DESCRIPTION
Up to this point, the npm module only had a command line interface. This
is not yet a production-ready module, but this is an important step to
get us there.
