### PR TITLE
Don't check truthiness of key and val in truthTest

### DIFF
--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -31,19 +31,17 @@ var truthTest = function truthTest(context, params, bodies, helperContext, test)
   var main = bodies.main;
 
   var elseBody = bodies["else"];
-  if (key && val) {
-    if (test(key, val)) {
-      var res = undefined;
-      if (main) {
-        res = main(context);
-      }
-      if (selectState) {
-        selectState.isResolved = true;
-      }
-      return res;
-    } else if (elseBody) {
-      return elseBody(context);
+  if (test(key, val)) {
+    var res = undefined;
+    if (main) {
+      res = main(context);
     }
+    if (selectState) {
+      selectState.isResolved = true;
+    }
+    return res;
+  } else if (elseBody) {
+    return elseBody(context);
   }
 
   // There are no appropriate bodies, so return an empty fragment

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,19 +24,17 @@ let truthTest = function(context, params, bodies, helperContext, test) {
   util.assert(val !== undefined, '@eq, @ne, @lt, @lte, @gt, @gte require a `val` parameter');
   let {main} = bodies;
   let elseBody = bodies.else;
-  if (key && val) {
-    if (test(key, val)) {
-      let res;
-      if (main) {
-        res = main(context);
-      }
-      if (selectState) {
-        selectState.isResolved = true;
-      }
-      return res;
-    } else if (elseBody) {
-      return elseBody(context);
+  if (test(key, val)) {
+    let res;
+    if (main) {
+      res = main(context);
     }
+    if (selectState) {
+      selectState.isResolved = true;
+    }
+    return res;
+  } else if (elseBody) {
+    return elseBody(context);
   }
 
   // There are no appropriate bodies, so return an empty fragment

--- a/test/acceptance/helper.js
+++ b/test/acceptance/helper.js
@@ -184,6 +184,18 @@ let suite = {
       })()
     },
     {
+      description: '@ne with with key and val of 0',
+      template: '{@ne key=0 val=0}<div>2 + 2</div>{:else}<div>These are equal :(</div>{/ne}',
+      context: {},
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        let div = document.createElement('div');
+        div.appendChild(document.createTextNode('These are equal :('));
+        frag.appendChild(div);
+        return frag;
+      })()
+    },
+    {
       description: '@ne with non-equal strings',
       template: '{@ne key="hello" val="bonjour"}<div>Bonjour, ça va?</div>{:else}<div>Huh?</div>{/ne}',
       context: {},


### PR DESCRIPTION
The existence of these values is already determined by the `assert`s, so
the if statement removed here was (1) redundant, and (2) inaccurate
since it failed on 0 and empty string.

Fixes #114
