### PR TITLE
Convert `exists` body to be a helper

### DIFF
--- a/dist/builtinHelpers.js
+++ b/dist/builtinHelpers.js
@@ -1,0 +1,44 @@
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+/*eslint no-debugger:0 */
+
+var util = _interopRequire(require("./util"));
+
+var helpers = {
+  /**
+   * Check if a value is truthy. If the value is a promise, wait until the promise resolves,
+   * then check if the resolved value is truthy.
+   */
+  exists: function exists(context, params, bodies, td) {
+    var key = params.key.split(".");
+    var val = td.get(context, key);
+    if (util.isPromise(val)) {
+      return val.then(function (data) {
+        if (util.isTruthy(data)) {
+          if (bodies.main) {
+            return bodies.main(context);
+          }
+        } else if (bodies["else"]) {
+          return bodies["else"](context);
+        }
+      })["catch"](function () {
+        if (bodies["else"]) {
+          return bodies["else"](context);
+        }
+      });
+    } else {
+      if (util.isTruthy(val)) {
+        if (bodies.main) {
+          return bodies.main(context);
+        }
+      } else if (bodies["else"]) {
+        return bodies["else"](context);
+      }
+    }
+  }
+};
+
+module.exports = helpers;
+//# sourceMappingURL=builtinHelpers.js.map

--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -6,6 +6,8 @@ var Context = _interopRequire(require("./compiler/context"));
 
 var escapableRaw = _interopRequire(require("./compiler/extensions/escapableRaw"));
 
+var builtinHelpers = _interopRequire(require("./compiler/extensions/builtinHelpers"));
+
 var htmlEntities = _interopRequire(require("./compiler/extensions/htmlEntities"));
 
 var adjustAttrs = _interopRequire(require("./compiler/extensions/adjustAttrs"));
@@ -63,7 +65,7 @@ var compiler = {
   }
 };
 
-compiler.useExtensions([escapableRaw, htmlEntities, adjustAttrs, buildInstructions]);
+compiler.useExtensions([builtinHelpers, escapableRaw, htmlEntities, adjustAttrs, buildInstructions]);
 
 module.exports = compiler;
 //# sourceMappingURL=compiler.js.map

--- a/dist/compiler/extensions/builtinHelpers.js
+++ b/dist/compiler/extensions/builtinHelpers.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var visitor = _interopRequire(require("../visitor"));
+
+var BUILT_IN_HELPER_TYPES = ["exists"];
+
+var generatedWalker = visitor.build({
+  TORNADO_BODY: function TORNADO_BODY(item) {
+    var node = item.node;
+
+    node = node[1];
+    if (BUILT_IN_HELPER_TYPES.indexOf(node.type) > -1) {
+      node.params.push(["TORNADO_PARAM", {
+        key: "key",
+        val: node.key.join(".")
+      }]);
+      node.key = [node.type];
+      node.type = "helper";
+    }
+  }
+});
+
+var builtinHelpers = {
+  transforms: [function (ast, options) {
+    return generatedWalker(ast, options.context);
+  }]
+};
+
+module.exports = builtinHelpers;
+//# sourceMappingURL=builtinHelpers.js.map

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -49,47 +49,65 @@ var truthTest = function truthTest(context, params, bodies, helperContext, test)
 };
 
 var helpers = {
-  sep: function sep(context, params, bodies, helperContext) {
+  sep: function sep(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     if (helperContext.get("$idx") < helperContext.get("$len") - 1) {
       return bodies.main(context);
     }
   },
-  first: function first(context, params, bodies, helperContext) {
+  first: function first(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     if (helperContext.get("$idx") === 0) {
       return bodies.main(context);
     }
   },
-  last: function last(context, params, bodies, helperContext) {
+  last: function last(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     if (helperContext.get("$idx") === helperContext.get("$len") - 1) {
       return bodies.main(context);
     }
   },
-  eq: function eq(context, params, bodies, helperContext) {
+  eq: function eq(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left === right;
     });
   },
-  ne: function ne(context, params, bodies, helperContext) {
+  ne: function ne(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left !== right;
     });
   },
-  gt: function gt(context, params, bodies, helperContext) {
+  gt: function gt(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left > right;
     });
   },
-  lt: function lt(context, params, bodies, helperContext) {
+  lt: function lt(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left < right;
     });
   },
-  gte: function gte(context, params, bodies, helperContext) {
+  gte: function gte(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left >= right;
     });
   },
-  lte: function lte(context, params, bodies, helperContext) {
+  lte: function lte(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     return truthTest(context, params, bodies, helperContext, function (left, right) {
       return left <= right;
     });
@@ -109,7 +127,8 @@ var helpers = {
   "debugger": function _debugger() {
     debugger;
   },
-  select: function select(context, params, bodies, helperContext) {
+  select: function select(context, params, bodies, td) {
+    var helperContext = td.helperContext;
     var key = params.key;
 
     util.assert(key !== undefined, "@select helper requires a `key` parameter");
@@ -119,13 +138,16 @@ var helpers = {
     });
     return bodies.main(context);
   },
-  "default": function _default(context, params, bodies, helperContext) {
+  "default": function _default(context, params, bodies, td) {
+    var helperContext = td.helperContext;
+
     var selectState = helperContext.get("$selectState");
     if (selectState && !selectState.isResolved) {
       return bodies.main(context);
     }
   },
-  math: function math(context, params, bodies, helperContext) {
+  math: function math(context, params, bodies, td) {
+    var helperContext = td.helperContext;
     var a = params.a;
     var b = params.b;
     var operator = params.operator;
@@ -188,7 +210,8 @@ var helpers = {
       return emptyFrag().appendChild(document.createTextNode(res));
     }
   },
-  repeat: function repeat(context, params, bodies, helperContext) {
+  repeat: function repeat(context, params, bodies, td) {
+    var helperContext = td.helperContext;
     var count = params.count;
     var main = bodies.main;
 

--- a/dist/runtime.js
+++ b/dist/runtime.js
@@ -4,6 +4,8 @@ var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["defau
 
 var util = _interopRequire(require("./util"));
 
+var builtinHelpers = _interopRequire(require("./builtinHelpers"));
+
 var helpers = _interopRequire(require("./helpers"));
 
 var tornado = {
@@ -376,11 +378,17 @@ var tornado = {
       if (this.util.hasPromises(paramVals)) {
         Promise.all(paramVals).then(function (values) {
           var resolvedParams = _this.util.arraysToObject(Object.keys(params).sort(), values);
-          var returnVal = helper(context, resolvedParams, bodies, _this.helperContext);
+          var returnVal = helper(context, resolvedParams, bodies, _this);
+          if (returnVal && _this.util.isPromise(returnVal)) {
+            placeholderNode = _this.insertPendingBody(placeholderNode, bodies.pending, context) || placeholderNode;
+          }
           return _this.helperResult(placeholderNode, returnVal);
         });
       } else {
-        var returnVal = helper(context, params, bodies, this.helperContext);
+        var returnVal = helper(context, params, bodies, this);
+        if (returnVal && this.util.isPromise(returnVal)) {
+          placeholderNode = this.insertPendingBody(placeholderNode, bodies.pending, context) || placeholderNode;
+        }
         var res = this.helperResult(placeholderNode, returnVal);
         this.helperContext.pop();
         return res;
@@ -598,6 +606,7 @@ tornado.h = tornado.helper;
 tornado.b = tornado.block;
 tornado.s = tornado.nodeToString;
 
+tornado.registerHelpers(builtinHelpers);
 tornado.registerHelpers(helpers);
 
 module.exports = tornado;

--- a/src/builtinHelpers.js
+++ b/src/builtinHelpers.js
@@ -1,0 +1,39 @@
+/*eslint no-debugger:0 */
+
+import util from './util';
+
+let helpers = {
+  /**
+   * Check if a value is truthy. If the value is a promise, wait until the promise resolves,
+   * then check if the resolved value is truthy.
+   */
+  exists(context, params, bodies, td) {
+    let key = params.key.split('.');
+    let val = td.get(context, key);
+    if (util.isPromise(val)) {
+      return val.then(data => {
+        if (util.isTruthy(data)) {
+          if (bodies.main) {
+            return bodies.main(context);
+          }
+        } else if (bodies.else) {
+          return bodies.else(context);
+        }
+      }).catch(() => {
+        if (bodies.else) {
+          return bodies.else(context);
+        }
+      });
+    } else {
+      if (util.isTruthy(val)) {
+        if (bodies.main) {
+          return bodies.main(context);
+        }
+      } else if (bodies.else) {
+        return bodies.else(context);
+      }
+    }
+  }
+};
+
+export default helpers;

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,6 +1,7 @@
 'use strict';
 import Context from './compiler/context';
 import escapableRaw from './compiler/extensions/escapableRaw';
+import builtinHelpers from './compiler/extensions/builtinHelpers';
 import htmlEntities from './compiler/extensions/htmlEntities';
 import adjustAttrs from './compiler/extensions/adjustAttrs';
 import buildInstructions from './compiler/extensions/buildInstructions';
@@ -47,6 +48,6 @@ let compiler = {
   }
 };
 
-compiler.useExtensions([escapableRaw, htmlEntities, adjustAttrs, buildInstructions]);
+compiler.useExtensions([builtinHelpers, escapableRaw, htmlEntities, adjustAttrs, buildInstructions]);
 
 export default compiler;

--- a/src/compiler/extensions/builtinHelpers.js
+++ b/src/compiler/extensions/builtinHelpers.js
@@ -1,0 +1,30 @@
+'use strict';
+import visitor from '../visitor';
+
+const BUILT_IN_HELPER_TYPES = ['exists'];
+
+let generatedWalker = visitor.build({
+  TORNADO_BODY(item) {
+    let {node} = item;
+    node = node[1];
+    if (BUILT_IN_HELPER_TYPES.indexOf(node.type) > -1) {
+      node.params.push([
+        'TORNADO_PARAM',
+        {
+          key: 'key',
+          val: node.key.join('.')
+        }
+      ]);
+      node.key = [node.type];
+      node.type = 'helper';
+    }
+  }
+});
+
+let builtinHelpers = {
+  transforms: [function (ast, options) {
+    return generatedWalker(ast, options.context);
+  }]
+};
+
+export default builtinHelpers;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,47 +42,56 @@ let truthTest = function(context, params, bodies, helperContext, test) {
 };
 
 let helpers = {
-  sep(context, params, bodies, helperContext) {
+  sep(context, params, bodies, td) {
+    let {helperContext} = td;
     if (helperContext.get('$idx') < helperContext.get('$len') - 1) {
       return bodies.main(context);
     }
   },
-  first(context, params, bodies, helperContext) {
+  first(context, params, bodies, td) {
+    let {helperContext} = td;
     if (helperContext.get('$idx') === 0) {
       return bodies.main(context);
     }
   },
-  last(context, params, bodies, helperContext) {
+  last(context, params, bodies, td) {
+    let {helperContext} = td;
     if (helperContext.get('$idx') === helperContext.get('$len') - 1) {
       return bodies.main(context);
     }
   },
-  eq(context, params, bodies, helperContext) {
+  eq(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left === right;
     });
   },
-  ne(context, params, bodies, helperContext) {
+  ne(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left !== right;
     });
   },
-  gt(context, params, bodies, helperContext) {
+  gt(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left > right;
     });
   },
-  lt(context, params, bodies, helperContext) {
+  lt(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left < right;
     });
   },
-  gte(context, params, bodies, helperContext) {
+  gte(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left >= right;
     });
   },
-  lte(context, params, bodies, helperContext) {
+  lte(context, params, bodies, td) {
+    let {helperContext} = td;
     return truthTest(context, params, bodies, helperContext, (left, right) => {
       return left <= right;
     });
@@ -102,7 +111,8 @@ let helpers = {
   debugger() {
     debugger;
   },
-  select(context, params, bodies, helperContext) {
+  select(context, params, bodies, td) {
+    let {helperContext} = td;
     let {key} = params;
     util.assert(key !== undefined, '@select helper requires a `key` parameter');
     helperContext.set('selectState', {
@@ -111,13 +121,15 @@ let helpers = {
     });
     return bodies.main(context);
   },
-  default(context, params, bodies, helperContext) {
+  default(context, params, bodies, td) {
+    let {helperContext} = td;
     let selectState = helperContext.get('$selectState');
     if (selectState && !selectState.isResolved) {
       return bodies.main(context);
     }
   },
-  math(context, params, bodies, helperContext) {
+  math(context, params, bodies, td) {
+    let {helperContext} = td;
     let {a, b, operator, round} = params;
     let {main} = bodies;
     let res;
@@ -176,7 +188,8 @@ let helpers = {
       return emptyFrag().appendChild(document.createTextNode(res));
     }
   },
-  repeat(context, params, bodies, helperContext) {
+  repeat(context, params, bodies, td) {
+    let {helperContext} = td;
     let {count} = params;
     let {main} = bodies;
     util.assert(typeof count === 'number' && count >= 0, '@repeat requires the `count` param, and it must be a number 0 or greater.');

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,4 +1,5 @@
 import util from './util';
+import builtinHelpers from './builtinHelpers';
 import helpers from './helpers';
 
 let tornado = {
@@ -348,11 +349,17 @@ let tornado = {
       if (this.util.hasPromises(paramVals)) {
         Promise.all(paramVals).then(values => {
           let resolvedParams = this.util.arraysToObject(Object.keys(params).sort(), values);
-          let returnVal = helper(context, resolvedParams, bodies, this.helperContext);
+          let returnVal = helper(context, resolvedParams, bodies, this);
+          if (returnVal && this.util.isPromise(returnVal)) {
+            placeholderNode = this.insertPendingBody(placeholderNode, bodies.pending, context) || placeholderNode;
+          }
           return this.helperResult(placeholderNode, returnVal);
         });
       } else {
-        let returnVal = helper(context, params, bodies, this.helperContext);
+        let returnVal = helper(context, params, bodies, this);
+        if (returnVal && this.util.isPromise(returnVal)) {
+          placeholderNode = this.insertPendingBody(placeholderNode, bodies.pending, context) || placeholderNode;
+        }
         let res = this.helperResult(placeholderNode, returnVal);
         this.helperContext.pop();
         return res;
@@ -565,6 +572,7 @@ tornado.h = tornado.helper;
 tornado.b = tornado.block;
 tornado.s = tornado.nodeToString;
 
+tornado.registerHelpers(builtinHelpers);
 tornado.registerHelpers(helpers);
 
 export default tornado;

--- a/test/acceptance/exists.js
+++ b/test/acceptance/exists.js
@@ -94,7 +94,6 @@ let suite = {
       expectedDom: (() => {
         let frag = document.createDocumentFragment();
         frag.appendChild(document.createTextNode('Hello, '));
-        frag.appendChild(document.createTextNode(''));
         return frag;
       })()
     },
@@ -105,7 +104,6 @@ let suite = {
       expectedDom: (() => {
         let frag = document.createDocumentFragment();
         frag.appendChild(document.createTextNode('Hello, '));
-        frag.appendChild(document.createTextNode(''));
         return frag;
       })()
     },
@@ -116,7 +114,6 @@ let suite = {
       expectedDom: (() => {
         let frag = document.createDocumentFragment();
         frag.appendChild(document.createTextNode('Hello, '));
-        frag.appendChild(document.createTextNode(''));
         return frag;
       })()
     },
@@ -196,7 +193,6 @@ let suite = {
       expectedDom: (() => {
         let frag = document.createDocumentFragment();
         frag.appendChild(document.createTextNode('Hello, '));
-        frag.appendChild(document.createTextNode(''));
         return frag;
       })()
     },

--- a/test/sandbox/index.html
+++ b/test/sandbox/index.html
@@ -8,25 +8,9 @@
   </head>
   <body>
     <div id="input">
-      <textarea id="template" placeholder="Template goes here"><h3>What's on reddit:</h3>
-<ul>
-  {#reddit.data.children}
-    <li>
-      {#data.thumbnail}
-        <img src="{.}">
-      {/data.thumbnail}
-      <p>{data.author}</p>
-      <a href="{data.url}">{data.title}</a>
-    </li>
-  {:pending}
-    <li><h4>Reddit is still loading ... &#9731;</h4></li>
-  {/reddit.data.children}
-</ul>
-</textarea>
+      <textarea id="template" placeholder="Template goes here">{?hello}hi{/hello}</textarea>
       <textarea id="context" placeholder="Context goes here">{
-  reddit: fetch('http://www.reddit.com/.json?limit=10').then(function(res) {
-  return res.json();
-  })
+  hello: 'yes'
 }</textarea>
       <button id="render">Render</button>
     </div>


### PR DESCRIPTION
Now `{?hello} ... {/hello}` is the same as `{@exists key="hello"} ...
{/exists}`

This change is significant because:
1. It ensures that any functionality that is available in builtin
   Tornado bodies can be implemented in a 3rd party helper
2. It prepares the way to further reduce the size of the runtime
3. It allows 3rd party developers to potentially overwrite the
   functionality of builtin Tornado bodies
