### PR TITLE
Turn sections params into helper context values

### DIFF
--- a/dist/builtinHelpers.js
+++ b/dist/builtinHelpers.js
@@ -82,6 +82,11 @@ var section = function section(context, params, bodies, td) {
   var val = td.get(context, key);
   var body = undefined,
       ctx = undefined;
+  Object.keys(params).forEach(function (key) {
+    if (key !== "key") {
+      td.helperContext.set(key, params[key]);
+    }
+  });
   if (util.isPromise(val)) {
     return val.then(function (data) {
       if (util.isTruthy(data)) {

--- a/dist/parser.js
+++ b/dist/parser.js
@@ -176,9 +176,13 @@ module.exports = (function() {
             }]
           },
         peg$c61 = function(key, val) {
+            var path = val.split('.');
+            if (val === '.') {
+              path = [];
+            }
             return ['TORNADO_PARAM', {
               key: key,
-              val: ['TORNADO_REFERENCE', {key: val.split('.'), filters: []}]
+              val: ['TORNADO_REFERENCE', {key: path}]
             }]
           },
         peg$c62 = /^[#?\^><+%:@\/~%]/,

--- a/src/builtinHelpers.js
+++ b/src/builtinHelpers.js
@@ -78,6 +78,11 @@ let section = function section(context, params, bodies, td) {
   let key = params.key.split('.');
   let val = td.get(context, key);
   let body, ctx;
+  Object.keys(params).forEach((key) => {
+    if (key !== 'key') {
+      td.helperContext.set(key, params[key]);
+    }
+  });
   if (util.isPromise(val)) {
     return val.then(data => {
       if (util.isTruthy(data)) {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -190,9 +190,13 @@ tornado_param
     }]
   }
   / key:key equals val:tornado_key {
+    var path = val.split('.');
+    if (val === '.') {
+      path = [];
+    }
     return ['TORNADO_PARAM', {
       key: key,
-      val: ['TORNADO_REFERENCE', {key: val.split('.'), filters: []}]
+      val: ['TORNADO_REFERENCE', {key: path}]
     }]
   }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -2,6 +2,41 @@ import util from './util';
 import builtinHelpers from './builtinHelpers';
 import helpers from './helpers';
 
+let lookup = (context, path) => {
+  let pathLength = path.length;
+  let newContext;
+  if (pathLength === 1) {
+    // there is only one more item left in the path
+    let key = path.pop();
+    let res = context[key];
+    if (res !== undefined) {
+      return util.isFunction(res) ? res.bind(context)() : res;
+    }
+  } else if (pathLength === 0) {
+    // return the current context for {.}
+    return context || '';
+  } else if (!pathLength || pathLength < 0) {
+    // There is something wrong with the path (maybe it was not an array?)
+    return '';
+  }
+  // There are still more steps in the array
+  newContext = context[path.shift()];
+  if (newContext) {
+    if (util.isFunction(newContext)) {
+      newContext = newContext.bind(context)();
+    }
+
+    if (util.isPromise(newContext)) {
+      return newContext.then(val => lookup(val, path));
+    }
+
+    if (util.isObject(newContext)) {
+      return lookup(newContext, path);
+    }
+  }
+  return '';
+};
+
 let tornado = {
 
   /**
@@ -34,6 +69,7 @@ let tornado = {
           return context[key];
         }
       }
+      return '';
     },
     set(key, val) {
       let context = this.peek();
@@ -99,42 +135,15 @@ let tornado = {
    * @return {*} The value at the end of the path, or an empty string.
    */
   get(context, path) {
-    let pathLength = path.length;
-    let newContext;
-    if (pathLength === 1) {
-      // there is only one more item left in the path
-      let key = path.pop();
-      let res = context[key];
-      if (res !== undefined) {
-        return this.util.isFunction(res) ? res.bind(context)() : res;
-      } else if (key[0] === '$' && this.helperContext.get(key) !== undefined) {
-        return this.helperContext.get(key);
+    if (path[0] && path[0][0] === '$') {
+      context = this.helperContext.get(path[0]);
+      if (path.length > 1 && util.isObject(context)) {
+        path = path.slice(1);
       } else {
-        return '';
-      }
-    } else if (pathLength === 0) {
-      // return the current context for {.}
-      return context || '';
-    } else if (!pathLength || pathLength < 0) {
-      // There is something wrong with the path (maybe it was not an array?)
-      return '';
-    }
-    // There are still more steps in the array
-    newContext = context[path.shift()];
-    if (newContext) {
-      if (this.util.isFunction(newContext)) {
-        newContext = newContext.bind(context)();
-      }
-
-      if (this.util.isPromise(newContext)) {
-        return newContext.then(val => this.get(val, path));
-      }
-
-      if (this.util.isObject(newContext)) {
-        return this.get(newContext, path);
+        return context;
       }
     }
-    return '';
+    return lookup(context, path);
   },
 
   /**

--- a/test/acceptance/helper.js
+++ b/test/acceptance/helper.js
@@ -1066,6 +1066,42 @@ let suite = {
         frag.appendChild(div);
         return frag;
       })()
+    },
+    {
+      description: 'Helper context dotted reference lookup',
+      template: '{#numbers root=root}{$root.symbol}{.}{/numbers}',
+      context: {
+        root: {
+          symbol: '#'
+        },
+        numbers: [1,2]
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('#'));
+        frag.appendChild(document.createTextNode('1'));
+        frag.appendChild(document.createTextNode('#'));
+        frag.appendChild(document.createTextNode('2'));
+        return frag;
+      })()
+    },
+    {
+      description: 'Helper context dotted reference, first step doesn\'t exist',
+      template: '{#numbers root=root}{$rot.symbol}{.}{/numbers}',
+      context: {
+        root: {
+          symbol: '#'
+        },
+        numbers: [1,2]
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode(''));
+        frag.appendChild(document.createTextNode('1'));
+        frag.appendChild(document.createTextNode(''));
+        frag.appendChild(document.createTextNode('2'));
+        return frag;
+      })()
     }
   ]
 };

--- a/test/acceptance/section.js
+++ b/test/acceptance/section.js
@@ -335,6 +335,55 @@ let suite = {
         frag.appendChild(document.createTextNode('Way fun!'));
         return frag;
       })()
+    },
+    {
+      description: 'Section with params',
+      template: '{#funds nationality="American"}More {$nationality} {currency}{/funds}',
+      context: {
+        funds: {
+          currency: 'dollars'
+        }
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('More '));
+        frag.appendChild(document.createTextNode('American'));
+        frag.appendChild(document.createTextNode(' '));
+        frag.appendChild(document.createTextNode('dollars'));
+        return frag;
+      })()
+    },
+    {
+      description: 'Section where param is an object',
+      template: '{#names root=root}{$root.greeting} {.}{/names}',
+      context: {
+        root: {
+          greeting: 'Hello!'
+        },
+        names: ['Steven']
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('Hello!'));
+        frag.appendChild(document.createTextNode(' '));
+        frag.appendChild(document.createTextNode('Steven'));
+        return frag;
+      })()
+    },
+    {
+      description: 'Section where param is current context',
+      template: '{#names root=.}{$root.greeting} {.}{/names}',
+      context: {
+        greeting: 'Hello!',
+        names: ['Steven']
+      },
+      expectedDom: (() => {
+        let frag = document.createDocumentFragment();
+        frag.appendChild(document.createTextNode('Hello!'));
+        frag.appendChild(document.createTextNode(' '));
+        frag.appendChild(document.createTextNode('Steven'));
+        return frag;
+      })()
     }
   ]
 };


### PR DESCRIPTION
Because Tornado does not allow you to look up the context, there needs
to be a way to reference data outside of a sections's context. This can
now be done with section params.

The section params are added to the helper context, and can be
referenced by using the param name, prefixed with a `$`. For example:

```
{#data outerValue=myVal}
  {$outerValue}
{/data}
```

The helper context can now hold objects and arrays instead of just
scalar values, and lookups on the helper context uses the same function
as lookups on the normal context (which means functions are called and
Promises are handled the same way).
