### PR TITLE
Create debugger as a compiler helper

### DIFF
--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -41,6 +41,7 @@ var compiler = {
     // TODO Don't mutate the results object. Have each pass return its result (and consume the
     // previous pass's result) instead.
     this.codeGenerator(results);
+    console.log(JSON.stringify(results.instructions, null, 2));
     this.postprocessor(results);
     return results.code;
   },

--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -18,13 +18,13 @@ var generateJS = _interopRequire(require("./compiler/extensions/generateJS"));
 
 var postprocess = _interopRequire(require("./compiler/extensions/postprocess"));
 
-var stages = ["checks", "transforms", "instructions"];
+var stages = ["checks", "transforms"];
 var compiler = {
   checks: [],
   transforms: [],
-  instructions: [],
   codeGenerator: generateJS,
   postprocessor: postprocess,
+  buildInstructions: buildInstructions,
   compile: function compile(ast, name /*, options*/) {
     var _this = this;
 
@@ -38,31 +38,39 @@ var compiler = {
         pass(ast, { results: results, context: context });
       });
     });
-    // TODO Don't mutate the results object. Have each pass return its result (and consume the
-    // previous pass's result) instead.
+
+    // TODO Clean up the instructions pass
+    var context = new Context(results);
+    this.buildInstructions.pass(ast, { results: results, context: context });
     this.codeGenerator(results);
-    console.log(JSON.stringify(results.instructions, null, 2));
     this.postprocessor(results);
     return results.code;
   },
-  useExtension: function useExtension(helper) {
+  useExtension: function useExtension(extension) {
     var _this = this;
 
     stages.forEach(function (passType) {
-      if (helper.hasOwnProperty(passType) && Array.isArray(helper[passType])) {
-        _this[passType] = _this[passType].concat(helper[passType]);
+      if (extension.hasOwnProperty(passType) && Array.isArray(extension[passType])) {
+        _this[passType] = _this[passType].concat(extension[passType]);
       }
     });
+    if (extension.hasOwnProperty("instructions")) {
+      var instructions = extension.instructions;
+      this.buildInstructions.addInstructions(instructions);
+    }
   },
-  useExtensions: function useExtensions(helpers) {
+  useExtensions: function useExtensions(extensions) {
     var _this = this;
 
-    helpers.forEach(function (helper) {
-      return _this.useExtension(helper);
+    extensions.forEach(function (extension) {
+      return _this.useExtension(extension);
     });
   },
   useCodeGenerator: function useCodeGenerator(generator) {
     this.codeGenerator = generator;
+  },
+  ready: function ready() {
+    this.buildInstructions.pass = this.buildInstructions.generateInstructions();
   }
 };
 

--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -42,7 +42,7 @@ var compiler = {
     // TODO Clean up the instructions pass
     var context = new Context(results);
     this.buildInstructions.pass(ast, { results: results, context: context });
-    this.codeGenerator(results);
+    this.codeGenerator.build(results);
     this.postprocessor(results);
     return results.code;
   },
@@ -55,8 +55,10 @@ var compiler = {
       }
     });
     if (extension.hasOwnProperty("instructions")) {
-      var instructions = extension.instructions;
-      this.buildInstructions.addInstructions(instructions);
+      this.buildInstructions.addInstructions(extension.instructions);
+    }
+    if (extension.hasOwnProperty("codeGen")) {
+      this.codeGenerator.useCodeGeneratorFns(extension.codeGen);
     }
   },
   useExtensions: function useExtensions(extensions) {
@@ -71,6 +73,7 @@ var compiler = {
   },
   ready: function ready() {
     this.buildInstructions.pass = this.buildInstructions.generateInstructions();
+    this.codeGenerator.build = this.codeGenerator.prepareGenerator();
   }
 };
 

--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -60,6 +60,7 @@ var compiler = {
     if (extension.hasOwnProperty("codeGen")) {
       this.codeGenerator.useCodeGeneratorFns(extension.codeGen);
     }
+    this.ready();
   },
   useExtensions: function useExtensions(extensions) {
     var _this = this;

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -20,6 +20,11 @@ var generateWalker = visitor.build({
       ctx.pushInstruction(new Instruction("close", { item: item, ctx: ctx }));
     }
   },
+  TORNADO_DEBUGGER: {
+    enter: function enter(item, ctx) {
+      ctx.pushInstruction(new Instruction("insert", { key: item.node[1].key, item: item, ctx: ctx }));
+    }
+  },
   TORNADO_REFERENCE: {
     enter: function enter(item, ctx) {
       ctx.pushInstruction(new Instruction("insert", { key: item.node[1].key, item: item, ctx: ctx }));

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -6,69 +6,123 @@ var visitor = _interopRequire(require("../visitor"));
 
 var Instruction = _interopRequire(require("../utils/Instruction"));
 
-var generateWalker = visitor.build({
+var instructionDefs = {
   TORNADO_PARTIAL: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { key: item.node[1].key, item: item, ctx: ctx }));
+      return {
+        type: "insert",
+        options: { key: item.node[1].key, item: item, ctx: ctx }
+      };
     }
   },
   TORNADO_BODY: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("open", { key: item.node[1].key, item: item, ctx: ctx }));
+      return {
+        type: "open",
+        options: { key: item.node[1].key, item: item, ctx: ctx }
+      };
     },
     leave: function leave(item, ctx) {
-      ctx.pushInstruction(new Instruction("close", { item: item, ctx: ctx }));
-    }
-  },
-  TORNADO_DEBUGGER: {
-    enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { key: item.node[1].key, item: item, ctx: ctx }));
+      return {
+        type: "close",
+        options: { item: item, ctx: ctx }
+      };
     }
   },
   TORNADO_REFERENCE: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { key: item.node[1].key, item: item, ctx: ctx }));
+      return {
+        type: "insert",
+        options: { key: item.node[1].key, item: item, ctx: ctx }
+      };
     }
   },
   TORNADO_COMMENT: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { item: item, ctx: ctx }));
+      return {
+        type: "insert",
+        options: { item: item, ctx: ctx }
+      };
     }
   },
   HTML_ELEMENT: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("open", { key: item.node[1].tag_info.key, item: item, ctx: ctx }));
+      return {
+        type: "open",
+        options: { key: item.node[1].tag_info.key, item: item, ctx: ctx }
+      };
     },
     leave: function leave(item, ctx) {
       item.state = item.previousState;
-      ctx.pushInstruction(new Instruction("close", { item: item, ctx: ctx }));
+      return {
+        type: "close",
+        options: { item: item, ctx: ctx }
+      };
     }
   },
   HTML_ATTRIBUTE: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("open", { item: item, ctx: ctx }));
+      return {
+        type: "open",
+        options: { item: item, ctx: ctx }
+      };
     },
     leave: function leave(item, ctx) {
-      ctx.pushInstruction(new Instruction("close", { item: item, ctx: ctx }));
+      return {
+        type: "close",
+        options: { item: item, ctx: ctx }
+      };
     }
   },
   HTML_COMMENT: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { item: item, ctx: ctx }));
+      return {
+        type: "insert",
+        options: { item: item, ctx: ctx }
+      };
     }
   },
   PLAIN_TEXT: {
     enter: function enter(item, ctx) {
-      ctx.pushInstruction(new Instruction("insert", { item: item, ctx: ctx }));
+      return {
+        type: "insert",
+        options: { item: item, ctx: ctx }
+      };
     }
   }
-});
-
-var generateInstructions = {
-  instructions: [function (ast, options) {
-    return generateWalker(ast, options.context);
-  }]
 };
 
-module.exports = generateInstructions;
+var buildInstructions = {
+  instructionDefs: {},
+  addInstruction: function addInstruction(name, instruction) {
+    var instructionDef = {
+      enter: instruction.enter ? function (item, ctx) {
+        var enter = instruction.enter(item, ctx);
+        ctx.pushInstruction(new Instruction(enter.type, enter.options));
+      } : null,
+      leave: instruction.leave ? function (item, ctx) {
+        var leave = instruction.leave(item, ctx);
+        ctx.pushInstruction(new Instruction(leave.type, leave.options));
+      } : null
+    };
+    this.instructionDefs[name] = instructionDef;
+  },
+  addInstructions: function addInstructions(instructions) {
+    var _this = this;
+
+    Object.keys(instructions).forEach(function (instructionName) {
+      _this.addInstruction(instructionName, instructions[instructionName]);
+    });
+  },
+  generateInstructions: function generateInstructions() {
+    var walker = visitor.build(this.instructionDefs);
+    return function (ast, options) {
+      return walker(ast, options.context);
+    };
+  }
+};
+
+buildInstructions.addInstructions(instructionDefs);
+
+module.exports = buildInstructions;
 //# sourceMappingURL=buildInstructions.js.map

--- a/dist/compiler/extensions/debugger.js
+++ b/dist/compiler/extensions/debugger.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var visitor = _interopRequire(require("../visitor"));
+
+var generatedWalker = visitor.build({
+  TORNADO_BODY: function TORNADO_BODY(item) {
+    var node = item.node;
+
+    var nodeInfo = node[1];
+    if (nodeInfo.type === "helper" && nodeInfo.key.join("") === "debugger") {
+      node[0] = "TORNADO_DEBUGGER";
+    }
+  }
+});
+
+var escapableRaw = {
+  transforms: [function (ast, options) {
+    return generatedWalker(ast, options.context);
+  }]
+};
+
+module.exports = escapableRaw;
+//# sourceMappingURL=debugger.js.map

--- a/dist/compiler/extensions/debugger.js
+++ b/dist/compiler/extensions/debugger.js
@@ -1,3 +1,5 @@
+/* eslint camelcase: 0 */
+
 "use strict";
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
@@ -27,6 +29,14 @@ var debuggerExtension = {
           options: { key: item.node[1].key, item: item, ctx: ctx }
         };
       }
+    }
+  },
+  codeGen: {
+    insert_TORNADO_DEBUGGER: function insert_TORNADO_DEBUGGER(instruction, code) {
+      var tdBody = instruction.tdBody;
+
+      var renderer = "      debugger;\n";
+      code.push(tdBody, { renderer: renderer });
     }
   }
 };

--- a/dist/compiler/extensions/debugger.js
+++ b/dist/compiler/extensions/debugger.js
@@ -15,11 +15,21 @@ var generatedWalker = visitor.build({
   }
 });
 
-var escapableRaw = {
+var debuggerExtension = {
   transforms: [function (ast, options) {
     return generatedWalker(ast, options.context);
-  }]
+  }],
+  instructions: {
+    TORNADO_DEBUGGER: {
+      enter: function enter(item, ctx) {
+        return {
+          type: "insert",
+          options: { key: item.node[1].key, item: item, ctx: ctx }
+        };
+      }
+    }
+  }
 };
 
-module.exports = escapableRaw;
+module.exports = debuggerExtension;
 //# sourceMappingURL=debugger.js.map

--- a/dist/compiler/extensions/generateJS.js
+++ b/dist/compiler/extensions/generateJS.js
@@ -45,6 +45,12 @@ codeGenerator.useCodeGeneratorFns({
       code.push(tdBody, { renderer: renderer });
     }
   },
+  insert_TORNADO_DEBUGGER: function insert_TORNADO_DEBUGGER(instruction, code) {
+    var tdBody = instruction.tdBody;
+
+    var renderer = "      debugger;\n";
+    code.push(tdBody, { renderer: renderer });
+  },
   open_TORNADO_BODY: function open_TORNADO_BODY(instruction, code) {
     var tdBody = instruction.tdBody;
     var bodyType = instruction.bodyType;

--- a/dist/compiler/extensions/generateJS.js
+++ b/dist/compiler/extensions/generateJS.js
@@ -13,24 +13,7 @@ var STATES = _utilsBuilder.STATES;
 
 var noop = function noop() {};
 
-var codeGenerator = {
-  generatorFns: {},
-  useCodeGeneratorFn: function useCodeGeneratorFn(codeGenerator) {
-    this.generatorFns[codeGenerator.name] = codeGenerator.method;
-  },
-  useCodeGeneratorFns: function useCodeGeneratorFns(codeGenerators) {
-    var _this = this;
-
-    Object.keys(codeGenerators).forEach(function (generatorName) {
-      return _this.useCodeGeneratorFn({ name: generatorName, method: codeGenerators[generatorName] });
-    });
-  },
-  build: function build() {
-    return generator.build(this.generatorFns);
-  }
-};
-
-codeGenerator.useCodeGeneratorFns({
+var generatorFns = {
   insert_TORNADO_PARTIAL: function insert_TORNADO_PARTIAL(instruction, code) {
     var tdBody = instruction.tdBody;
     var key = instruction.key;
@@ -44,12 +27,6 @@ codeGenerator.useCodeGeneratorFns({
       var renderer = "td." + util.getTdMethodName("getPartial") + "('" + key + "', " + context + ", this).then(function(node){return td." + util.getTdMethodName("nodeToString") + "(node)}),";
       code.push(tdBody, { renderer: renderer });
     }
-  },
-  insert_TORNADO_DEBUGGER: function insert_TORNADO_DEBUGGER(instruction, code) {
-    var tdBody = instruction.tdBody;
-
-    var renderer = "      debugger;\n";
-    code.push(tdBody, { renderer: renderer });
   },
   open_TORNADO_BODY: function open_TORNADO_BODY(instruction, code) {
     var tdBody = instruction.tdBody;
@@ -304,47 +281,64 @@ codeGenerator.useCodeGeneratorFns({
     }, []);
     return "{" + paramsHash.join(",") + "}";
   }
-});
-
-var generateJavascript = function generateJavascript(results) {
-  results.code = {
-    fragments: [],
-    renderers: [],
-    push: function push(idx, strings) {
-      var fragment = strings.fragment;
-      var renderer = strings.renderer;
-
-      if (idx >= this.fragments.length) {
-        if (fragment) {
-          this.fragments.push(fragment);
-        }
-        if (renderer) {
-          this.renderers.push(renderer);
-        }
-      } else {
-        if (fragment) {
-          this.fragments[idx] += fragment;
-        }
-        if (renderer) {
-          this.renderers[idx] += renderer;
-        }
-      }
-    },
-    /**
-     * Remove characters from the generated code.
-     * @param {String} type Either 'fragments' or 'renderers'
-     * @param {Number} idx The index of the fragment or renderer from which the characters are to be removed
-     * @param {Number} start The character position to start slicing from
-     * @param {Number} end The character position where the slice ends
-     */
-    slice: function slice(type, idx, start, end) {
-      if (this[type] && this[type][idx]) {
-        this[type][idx] = this[type][idx].slice(start, end);
-      }
-    }
-  };
-  return codeGenerator.build()(results.instructions, results.code);
 };
 
-module.exports = generateJavascript;
+var codeGenerator = {
+  generatorFns: {},
+  useCodeGeneratorFn: function useCodeGeneratorFn(codeGenerator) {
+    this.generatorFns[codeGenerator.name] = codeGenerator.method;
+  },
+  useCodeGeneratorFns: function useCodeGeneratorFns(codeGenerators) {
+    var _this = this;
+
+    Object.keys(codeGenerators).forEach(function (generatorName) {
+      return _this.useCodeGeneratorFn({ name: generatorName, method: codeGenerators[generatorName] });
+    });
+  },
+  prepareGenerator: function prepareGenerator() {
+    return function (results) {
+      results.code = {
+        fragments: [],
+        renderers: [],
+        push: function push(idx, strings) {
+          var fragment = strings.fragment;
+          var renderer = strings.renderer;
+
+          if (idx >= this.fragments.length) {
+            if (fragment) {
+              this.fragments.push(fragment);
+            }
+            if (renderer) {
+              this.renderers.push(renderer);
+            }
+          } else {
+            if (fragment) {
+              this.fragments[idx] += fragment;
+            }
+            if (renderer) {
+              this.renderers[idx] += renderer;
+            }
+          }
+        },
+        /**
+         * Remove characters from the generated code.
+         * @param {String} type Either 'fragments' or 'renderers'
+         * @param {Number} idx The index of the fragment or renderer from which the characters are to be removed
+         * @param {Number} start The character position to start slicing from
+         * @param {Number} end The character position where the slice ends
+         */
+        slice: function slice(type, idx, start, end) {
+          if (this[type] && this[type][idx]) {
+            this[type][idx] = this[type][idx].slice(start, end);
+          }
+        }
+      };
+      return generator.build(this.generatorFns)(results.instructions, results.code);
+    };
+  }
+};
+
+codeGenerator.useCodeGeneratorFns(generatorFns);
+
+module.exports = codeGenerator;
 //# sourceMappingURL=generateJS.js.map

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -124,9 +124,6 @@ var helpers = {
       return frag;
     }
   },
-  "debugger": function _debugger() {
-    debugger;
-  },
   select: function select(context, params, bodies, td) {
     var helperContext = td.helperContext;
     var key = params.key;

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -47,6 +47,7 @@ let compiler = {
     if (extension.hasOwnProperty('codeGen')) {
       this.codeGenerator.useCodeGeneratorFns(extension.codeGen);
     }
+    this.ready();
   },
   useExtensions(extensions) {
     extensions.forEach(extension => this.useExtension(extension));

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -30,6 +30,7 @@ let compiler = {
     // TODO Don't mutate the results object. Have each pass return its result (and consume the
     // previous pass's result) instead.
     this.codeGenerator(results);
+    console.log(JSON.stringify(results.instructions, null, 2));
     this.postprocessor(results);
     return results.code;
   },

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -31,7 +31,7 @@ let compiler = {
     // TODO Clean up the instructions pass
     let context = new Context(results);
     this.buildInstructions.pass(ast, {results, context});
-    this.codeGenerator(results);
+    this.codeGenerator.build(results);
     this.postprocessor(results);
     return results.code;
   },
@@ -42,8 +42,10 @@ let compiler = {
       }
     });
     if (extension.hasOwnProperty('instructions')) {
-      let instructions = extension.instructions;
-      this.buildInstructions.addInstructions(instructions);
+      this.buildInstructions.addInstructions(extension.instructions);
+    }
+    if (extension.hasOwnProperty('codeGen')) {
+      this.codeGenerator.useCodeGeneratorFns(extension.codeGen);
     }
   },
   useExtensions(extensions) {
@@ -54,6 +56,7 @@ let compiler = {
   },
   ready() {
     this.buildInstructions.pass = this.buildInstructions.generateInstructions();
+    this.codeGenerator.build = this.codeGenerator.prepareGenerator();
   }
 };
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -9,13 +9,13 @@ import generateJS from './compiler/extensions/generateJS';
 import postprocess from './compiler/extensions/postprocess';
 
 
-const stages = ['checks', 'transforms', 'instructions'];
+const stages = ['checks', 'transforms'];
 let compiler = {
   checks: [],
   transforms: [],
-  instructions: [],
   codeGenerator: generateJS,
   postprocessor: postprocess,
+  buildInstructions,
   compile(ast, name/*, options*/) {
     let results = {
       name,
@@ -27,25 +27,33 @@ let compiler = {
         pass(ast, {results, context});
       });
     });
-    // TODO Don't mutate the results object. Have each pass return its result (and consume the
-    // previous pass's result) instead.
+
+    // TODO Clean up the instructions pass
+    let context = new Context(results);
+    this.buildInstructions.pass(ast, {results, context});
     this.codeGenerator(results);
-    console.log(JSON.stringify(results.instructions, null, 2));
     this.postprocessor(results);
     return results.code;
   },
-  useExtension(helper) {
+  useExtension(extension) {
     stages.forEach(passType => {
-      if (helper.hasOwnProperty(passType) && Array.isArray(helper[passType])) {
-        this[passType] = this[passType].concat(helper[passType]);
+      if (extension.hasOwnProperty(passType) && Array.isArray(extension[passType])) {
+        this[passType] = this[passType].concat(extension[passType]);
       }
     });
+    if (extension.hasOwnProperty('instructions')) {
+      let instructions = extension.instructions;
+      this.buildInstructions.addInstructions(instructions);
+    }
   },
-  useExtensions(helpers) {
-    helpers.forEach(helper => this.useExtension(helper));
+  useExtensions(extensions) {
+    extensions.forEach(extension => this.useExtension(extension));
   },
   useCodeGenerator(generator) {
     this.codeGenerator = generator;
+  },
+  ready() {
+    this.buildInstructions.pass = this.buildInstructions.generateInstructions();
   }
 };
 

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -17,6 +17,11 @@ let generateWalker = visitor.build({
       ctx.pushInstruction(new Instruction('close', {item, ctx}));
     }
   },
+  TORNADO_DEBUGGER: {
+    enter(item, ctx) {
+      ctx.pushInstruction(new Instruction('insert', {key: item.node[1].key, item, ctx}));
+    }
+  },
   TORNADO_REFERENCE: {
     enter(item, ctx) {
       ctx.pushInstruction(new Instruction('insert', {key: item.node[1].key, item, ctx}));

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -3,68 +3,120 @@
 import visitor from '../visitor';
 import Instruction from '../utils/Instruction';
 
-let generateWalker = visitor.build({
+let instructionDefs = {
   TORNADO_PARTIAL: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {key: item.node[1].key, item, ctx}));
+      return {
+        type: 'insert',
+        options: {key: item.node[1].key, item, ctx}
+      };
     }
   },
   TORNADO_BODY: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('open', {key: item.node[1].key, item, ctx}));
+      return {
+        type: 'open',
+        options: {key: item.node[1].key, item, ctx}
+      };
     },
     leave(item, ctx) {
-      ctx.pushInstruction(new Instruction('close', {item, ctx}));
-    }
-  },
-  TORNADO_DEBUGGER: {
-    enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {key: item.node[1].key, item, ctx}));
+      return {
+        type: 'close',
+        options: {item, ctx}
+      };
     }
   },
   TORNADO_REFERENCE: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {key: item.node[1].key, item, ctx}));
+      return {
+        type: 'insert',
+        options: {key: item.node[1].key, item, ctx}
+      };
     }
   },
   TORNADO_COMMENT: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {item, ctx}));
+      return {
+        type: 'insert',
+        options: {item, ctx}
+      };
     }
   },
   HTML_ELEMENT: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('open', {key: item.node[1].tag_info.key, item, ctx}));
+      return {
+        type: 'open',
+        options: {key: item.node[1].tag_info.key, item, ctx}
+      };
     },
     leave(item, ctx){
       item.state = item.previousState;
-      ctx.pushInstruction(new Instruction('close', {item, ctx}));
+      return {
+        type: 'close',
+        options: {item, ctx}
+      };
     }
   },
   HTML_ATTRIBUTE: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('open', {item, ctx}));
+      return {
+        type: 'open',
+        options: {item, ctx}
+      };
     },
     leave(item, ctx) {
-      ctx.pushInstruction(new Instruction('close', {item, ctx}));
+      return {
+        type: 'close',
+        options: {item, ctx}
+      };
     }
   },
   HTML_COMMENT: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {item, ctx}));
+      return {
+        type: 'insert',
+        options: {item, ctx}
+      };
     }
   },
   PLAIN_TEXT: {
     enter(item, ctx) {
-      ctx.pushInstruction(new Instruction('insert', {item, ctx}));
+      return {
+        type: 'insert',
+        options: {item, ctx}
+      };
     }
   }
-});
-
-let generateInstructions = {
-  instructions: [function (ast, options) {
-    return generateWalker(ast, options.context);
-  }]
 };
 
-export default generateInstructions;
+let buildInstructions = {
+  instructionDefs: {},
+  addInstruction(name, instruction) {
+    let instructionDef = {
+      enter: instruction.enter ? (item, ctx) => {
+        let enter = instruction.enter(item, ctx);
+        ctx.pushInstruction(new Instruction(enter.type, enter.options));
+      } : null,
+      leave: instruction.leave ? (item, ctx) => {
+        let leave = instruction.leave(item, ctx);
+        ctx.pushInstruction(new Instruction(leave.type, leave.options));
+      } : null
+    };
+    this.instructionDefs[name] = instructionDef;
+  },
+  addInstructions(instructions) {
+    Object.keys(instructions).forEach(instructionName => {
+      this.addInstruction(instructionName, instructions[instructionName]);
+    });
+  },
+  generateInstructions() {
+    let walker = visitor.build(this.instructionDefs);
+    return function(ast, options) {
+      return walker(ast, options.context);
+    };
+  }
+};
+
+buildInstructions.addInstructions(instructionDefs);
+
+export default buildInstructions;

--- a/src/compiler/extensions/debugger.js
+++ b/src/compiler/extensions/debugger.js
@@ -11,10 +11,20 @@ let generatedWalker = visitor.build({
   }
 });
 
-let escapableRaw = {
+let debuggerExtension = {
   transforms: [function (ast, options) {
     return generatedWalker(ast, options.context);
-  }]
+  }],
+  instructions: {
+    TORNADO_DEBUGGER: {
+      enter(item, ctx) {
+        return {
+          type: 'insert',
+          options: {key: item.node[1].key, item, ctx}
+        };
+      }
+    }
+  }
 };
 
-export default escapableRaw;
+export default debuggerExtension;

--- a/src/compiler/extensions/debugger.js
+++ b/src/compiler/extensions/debugger.js
@@ -1,0 +1,20 @@
+'use strict';
+import visitor from '../visitor';
+
+let generatedWalker = visitor.build({
+  TORNADO_BODY(item) {
+    let {node} = item;
+    let nodeInfo = node[1];
+    if (nodeInfo.type === 'helper' && nodeInfo.key.join('') === 'debugger') {
+      node[0] = 'TORNADO_DEBUGGER';
+    }
+  }
+});
+
+let escapableRaw = {
+  transforms: [function (ast, options) {
+    return generatedWalker(ast, options.context);
+  }]
+};
+
+export default escapableRaw;

--- a/src/compiler/extensions/debugger.js
+++ b/src/compiler/extensions/debugger.js
@@ -1,3 +1,5 @@
+/* eslint camelcase: 0 */
+
 'use strict';
 import visitor from '../visitor';
 
@@ -23,6 +25,13 @@ let debuggerExtension = {
           options: {key: item.node[1].key, item, ctx}
         };
       }
+    }
+  },
+  codeGen: {
+    insert_TORNADO_DEBUGGER(instruction, code) {
+      let {tdBody} = instruction;
+      let renderer = '      debugger;\n';
+      code.push(tdBody, {renderer});
     }
   }
 };

--- a/src/compiler/extensions/generateJS.js
+++ b/src/compiler/extensions/generateJS.js
@@ -5,23 +5,9 @@ import generator from '../codeGenerator';
 import util from '../utils/builder';
 import {STATES} from '../utils/builder';
 
-let noop = function() {};
+const noop = function() {};
 
-let codeGenerator = {
-  generatorFns: {},
-  useCodeGeneratorFn(codeGenerator) {
-    this.generatorFns[codeGenerator.name] = codeGenerator.method;
-  },
-  useCodeGeneratorFns(codeGenerators) {
-    Object.keys(codeGenerators)
-    .forEach(generatorName => this.useCodeGeneratorFn({name: generatorName, method: codeGenerators[generatorName]}));
-  },
-  build() {
-    return generator.build(this.generatorFns);
-  }
-};
-
-codeGenerator.useCodeGeneratorFns({
+let generatorFns = {
   insert_TORNADO_PARTIAL(instruction, code) {
     let {tdBody, key} = instruction;
     let context = 'c';
@@ -33,11 +19,6 @@ codeGenerator.useCodeGeneratorFns({
       let renderer = `td.${util.getTdMethodName('getPartial')}('${key}', ${context}, this).then(function(node){return td.${util.getTdMethodName('nodeToString')}(node)}),`;
       code.push(tdBody, {renderer});
     }
-  },
-  insert_TORNADO_DEBUGGER(instruction, code) {
-    let {tdBody} = instruction;
-    let renderer = '      debugger;\n';
-    code.push(tdBody, {renderer});
   },
   open_TORNADO_BODY(instruction, code) {
     let {tdBody, bodyType, tdMethodName, needsOwnMethod} = instruction;
@@ -248,44 +229,58 @@ codeGenerator.useCodeGeneratorFns({
     }, []);
     return `{${paramsHash.join(',')}}`;
   }
-});
-
-let generateJavascript = function (results) {
-  results.code = {
-    fragments: [],
-    renderers: [],
-    push(idx, strings) {
-      let {fragment, renderer} = strings;
-      if (idx >= this.fragments.length) {
-        if (fragment) {
-          this.fragments.push(fragment);
-        }
-        if (renderer) {
-          this.renderers.push(renderer);
-        }
-      } else {
-        if (fragment) {
-          this.fragments[idx] += fragment;
-        }
-        if (renderer) {
-          this.renderers[idx] += renderer;
-        }
-      }
-    },
-    /**
-     * Remove characters from the generated code.
-     * @param {String} type Either 'fragments' or 'renderers'
-     * @param {Number} idx The index of the fragment or renderer from which the characters are to be removed
-     * @param {Number} start The character position to start slicing from
-     * @param {Number} end The character position where the slice ends
-     */
-    slice(type, idx, start, end) {
-      if (this[type] && this[type][idx]) {
-        this[type][idx] = this[type][idx].slice(start, end);
-      }
-    }
-  };
-  return codeGenerator.build()(results.instructions, results.code);
 };
 
-export default generateJavascript;
+let codeGenerator = {
+  generatorFns: {},
+  useCodeGeneratorFn(codeGenerator) {
+    this.generatorFns[codeGenerator.name] = codeGenerator.method;
+  },
+  useCodeGeneratorFns(codeGenerators) {
+    Object.keys(codeGenerators)
+    .forEach(generatorName => this.useCodeGeneratorFn({name: generatorName, method: codeGenerators[generatorName]}));
+  },
+  prepareGenerator() {
+    return function(results) {
+      results.code = {
+        fragments: [],
+        renderers: [],
+        push(idx, strings) {
+          let {fragment, renderer} = strings;
+          if (idx >= this.fragments.length) {
+            if (fragment) {
+              this.fragments.push(fragment);
+            }
+            if (renderer) {
+              this.renderers.push(renderer);
+            }
+          } else {
+            if (fragment) {
+              this.fragments[idx] += fragment;
+            }
+            if (renderer) {
+              this.renderers[idx] += renderer;
+            }
+          }
+        },
+        /**
+         * Remove characters from the generated code.
+         * @param {String} type Either 'fragments' or 'renderers'
+         * @param {Number} idx The index of the fragment or renderer from which the characters are to be removed
+         * @param {Number} start The character position to start slicing from
+         * @param {Number} end The character position where the slice ends
+         */
+        slice(type, idx, start, end) {
+          if (this[type] && this[type][idx]) {
+            this[type][idx] = this[type][idx].slice(start, end);
+          }
+        }
+      };
+      return generator.build(this.generatorFns)(results.instructions, results.code);
+    };
+  }
+};
+
+codeGenerator.useCodeGeneratorFns(generatorFns);
+
+export default codeGenerator;

--- a/src/compiler/extensions/generateJS.js
+++ b/src/compiler/extensions/generateJS.js
@@ -34,6 +34,11 @@ codeGenerator.useCodeGeneratorFns({
       code.push(tdBody, {renderer});
     }
   },
+  insert_TORNADO_DEBUGGER(instruction, code) {
+    let {tdBody} = instruction;
+    let renderer = '      debugger;\n';
+    code.push(tdBody, {renderer});
+  },
   open_TORNADO_BODY(instruction, code) {
     let {tdBody, bodyType, tdMethodName, needsOwnMethod} = instruction;
     if (needsOwnMethod) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -108,9 +108,6 @@ let helpers = {
       return frag;
     }
   },
-  debugger() {
-    debugger;
-  },
   select(context, params, bodies, td) {
     let {helperContext} = td;
     let {key} = params;

--- a/test/sandbox/index.html
+++ b/test/sandbox/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="input">
-      <textarea id="template" placeholder="Template goes here">{#hello}{.}{/hello}</textarea>
+      <textarea id="template" placeholder="Template goes here">{#hello}{@debugger/}{/hello}</textarea>
       <textarea id="context" placeholder="Context goes here">{
   hello: ['yes']
 }</textarea>

--- a/test/sandbox/sandbox.js
+++ b/test/sandbox/sandbox.js
@@ -16,6 +16,8 @@ var stringContainer = document.querySelector('#output .string');
 
 compiler.useExtension(tdDebugger);
 
+compiler.ready();
+
 button.addEventListener('click', function() {
   var t = templateTextArea.value;
   var c = contextTextArea.value;

--- a/test/sandbox/sandbox.js
+++ b/test/sandbox/sandbox.js
@@ -1,5 +1,6 @@
 var parser = require('../../dist/parser'),
     compiler = require('../../dist/compiler'),
+    tdDebugger = require('../../dist/compiler/extensions/debugger'),
     td = require('../../dist/runtime');
 
 window.td = td;
@@ -10,6 +11,10 @@ var astContainer = document.querySelector('#output .ast');
 var compiledContainer = document.querySelector('#output .compiled');
 var outputContainer = document.querySelector('#output .output');
 var stringContainer = document.querySelector('#output .string');
+
+// Customize compiler
+
+compiler.useExtension(tdDebugger);
 
 button.addEventListener('click', function() {
   var t = templateTextArea.value;

--- a/test/sandbox/sandbox.js
+++ b/test/sandbox/sandbox.js
@@ -16,8 +16,6 @@ var stringContainer = document.querySelector('#output .string');
 
 compiler.useExtension(tdDebugger);
 
-compiler.ready();
-
 button.addEventListener('click', function() {
   var t = templateTextArea.value;
   var c = contextTextArea.value;


### PR DESCRIPTION
## What is included in this PR:
- The debugger helper now inserts a `debugger;` statement directly into the compiled template.
- Extensions can add instructions
- Instructions aren't really passes anymore - they happen after the passes are done (sort of like the code generator and post process).
  - This is necessary to allow extensions to add instructions. Before `buildInstructions` was one of the extensions, and allow extensions to extend extensions would have been a little too wild.
- The compiler now has a `ready` method that should be called before the compiler is used. The `ready` method is called after all of the extensions have been added by the application code.
