### PR TITLE
Replace parentTdBody, tdBody, indexPath with a FrameStack

### DIFF
--- a/dist/compiler/context.js
+++ b/dist/compiler/context.js
@@ -43,7 +43,7 @@ var STATES = {
 };
 
 var Context = function Context(results) {
-  var nodeStack = [{ indexPath: [] }];
+  var nodeStack = [{}];
   var defaultState = STATES.OUTER_SPACE;
 
   var context = {
@@ -76,10 +76,7 @@ var Context = function Context(results) {
     stack: {
       push: function push(node, index, method) {
         var nodeType = node[0];
-        var parentIndexPath = this.stack.peek("indexPath");
         var isTornadoBody = nodeType === "TORNADO_BODY";
-        var isParentTdBody = this.stack.peek("nodeType") === "TORNADO_BODY";
-        var isAttr = nodeType === "HTML_ATTRIBUTE";
         var namespace = "";
         var blockName = undefined,
             blockIndex = undefined;
@@ -89,14 +86,7 @@ var Context = function Context(results) {
         if (nodeType === "HTML_ELEMENT" || nodeType === "HTML_ATTRIBUTE") {
           namespace = this.getCurrentNamespace(namespace);
         }
-        var indexPath = parentIndexPath.slice(0);
         var state = this.getCurrentState();
-        if (isParentTdBody) {
-          indexPath = [];
-        }
-        if (!isAttr) {
-          indexPath.push(index);
-        }
 
         if (isTornadoBody) {
           var bodyType = node[1].type;
@@ -118,7 +108,6 @@ var Context = function Context(results) {
         var stackItem = {
           node: node,
           nodeType: nodeType,
-          indexPath: indexPath,
           state: state,
           previousState: this.stack.peek("state"),
           blockName: blockName,

--- a/dist/compiler/context.js
+++ b/dist/compiler/context.js
@@ -44,32 +44,11 @@ var STATES = {
 
 var Context = function Context(results) {
   var nodeStack = [{ indexPath: [] }];
-  // let refCount;
-  var tornadoBodiesPointer = -1;
   var defaultState = STATES.OUTER_SPACE;
 
   var context = {
     blocks: {},
     state: defaultState,
-    getCurrentTdBody: function getCurrentTdBody(nodeType) {
-      if (nodeType === "TORNADO_BODY") {
-        return tornadoBodiesPointer;
-      } else {
-        return this.stack.peek("tdBody");
-      }
-    },
-    getElContainer: function getElContainer() {
-      var container = this.stack.peek("parentNodeIdx");
-      var nodeType = this.stack.peek("nodeType");
-      if (nodeType === "TORNADO_BODY") {
-        return -1;
-      } else if (nodeType === "HTML_ELEMENT") {
-        return container + 1;
-      }
-    },
-    incrementCurrentTdBody: function incrementCurrentTdBody() {
-      tornadoBodiesPointer++;
-    },
     pushInstruction: function pushInstruction(instruction) {
       results.instructions.push(instruction);
     },
@@ -102,8 +81,7 @@ var Context = function Context(results) {
         var isParentTdBody = this.stack.peek("nodeType") === "TORNADO_BODY";
         var isAttr = nodeType === "HTML_ATTRIBUTE";
         var namespace = "";
-        var parentTdBody = undefined,
-            blockName = undefined,
+        var blockName = undefined,
             blockIndex = undefined;
         if (nodeType === "HTML_ELEMENT") {
           namespace = this.getNamespaceFromNode(node);
@@ -122,10 +100,6 @@ var Context = function Context(results) {
 
         if (isTornadoBody) {
           var bodyType = node[1].type;
-          parentTdBody = this.stack.peek("tdBody");
-          if (node[1].body && node[1].body.length) {
-            this.incrementCurrentTdBody();
-          }
           if (bodyType === "block" || bodyType === "inlinePartial") {
             blockName = node[1].key.join(".");
             if (bodyType === "block") {
@@ -149,10 +123,7 @@ var Context = function Context(results) {
           previousState: this.stack.peek("state"),
           blockName: blockName,
           blockIndex: blockIndex,
-          namespace: namespace,
-          tdBody: this.getCurrentTdBody(nodeType),
-          parentTdBody: parentTdBody,
-          parentNodeIdx: this.getElContainer()
+          namespace: namespace
         };
         nodeStack.push(stackItem);
         method(stackItem, this);

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -6,65 +6,81 @@ var visitor = _interopRequire(require("../visitors/visitor"));
 
 var Instruction = _interopRequire(require("../utils/Instruction"));
 
+var FrameStack = _interopRequire(require("../utils/FrameStack"));
+
 var instructionDefs = {
-  TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx) {
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, ctx: ctx }));
+  TEMPLATE: function TEMPLATE(node, ctx, fs) {
+    fs.reset();
+  },
+  TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, fs) {
+    // we are not creating a new tdBody for partials
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
   },
   TORNADO_BODY: {
-    enter: function enter(node, ctx) {
+    enter: function enter(node, ctx, fs) {
+      if (node[1].body && node[1].body.length) {
+        fs.pushTd();
+      }
       return {
         type: "open",
-        options: { key: node[1].key, item: node.stackItem, ctx: ctx }
+        options: { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }
       };
     },
-    leave: function leave(node, ctx) {
+    leave: function leave(node, ctx, fs) {
+      var prev = fs.current();
+      if (node[1].body && node[1].body.length) {
+        fs.popTd();
+      }
       return {
         type: "close",
-        options: { item: node.stackItem, ctx: ctx }
+        options: { item: node.stackItem, frameStack: prev, ctx: ctx }
       };
     }
   },
-  TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx) {
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, ctx: ctx }));
+  TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
   },
-  TORNADO_COMMENT: function TORNADO_COMMENT(node, ctx) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, ctx: ctx }));
+  TORNADO_COMMENT: function TORNADO_COMMENT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
   },
   HTML_ELEMENT: {
-    enter: function enter(node, ctx) {
+    enter: function enter(node, ctx, fs) {
+      fs.pushEl();
       return {
         type: "open",
-        options: { key: node[1].tag_info.key, item: node.stackItem, ctx: ctx }
+        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }
       };
     },
-    leave: function leave(node, ctx) {
+    leave: function leave(node, ctx, fs) {
       var item = node.stackItem;
       item.state = item.previousState;
+      var prev = fs.current();
+      fs.popEl();
       return {
         type: "close",
-        options: { item: item, ctx: ctx }
+        options: { item: item, frameStack: prev, ctx: ctx }
       };
     }
   },
   HTML_ATTRIBUTE: {
-    enter: function enter(node, ctx) {
+    enter: function enter(node, ctx, fs) {
       return {
         type: "open",
-        options: { item: node.stackItem, ctx: ctx }
+        options: { item: node.stackItem, frameStack: fs.current(), ctx: ctx }
       };
     },
-    leave: function leave(node, ctx) {
+    leave: function leave(node, ctx, fs) {
       return {
         type: "close",
-        options: { item: node.stackItem, ctx: ctx }
+        options: { item: node.stackItem, frameStack: fs.current(), ctx: ctx }
       };
     }
   },
-  HTML_COMMENT: function HTML_COMMENT(node, ctx) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, ctx: ctx }));
+  HTML_COMMENT: function HTML_COMMENT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
   },
-  PLAIN_TEXT: function PLAIN_TEXT(node, ctx) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, ctx: ctx }));
+  PLAIN_TEXT: function PLAIN_TEXT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
   }
 };
 
@@ -75,12 +91,14 @@ var buildInstructions = {
       this.instructionDefs[name] = instruction;
     } else {
       var instructionDef = {
-        enter: instruction.enter ? function (node, ctx) {
-          var enter = instruction.enter(node, ctx);
+        enter: instruction.enter ? function () {
+          var ctx = arguments[1];
+          var enter = instruction.enter.apply(null, arguments);
           ctx.pushInstruction(new Instruction(enter.type, enter.options));
         } : null,
-        leave: instruction.leave ? function (node, ctx) {
-          var leave = instruction.leave(node, ctx);
+        leave: instruction.leave ? function () {
+          var ctx = arguments[1];
+          var leave = instruction.leave.apply(null, arguments);
           ctx.pushInstruction(new Instruction(leave.type, leave.options));
         } : null
       };
@@ -95,9 +113,10 @@ var buildInstructions = {
     });
   },
   generateInstructions: function generateInstructions() {
+    var frameStack = new FrameStack();
     var walker = visitor.build(this.instructionDefs);
     return function (ast, options) {
-      return walker(ast, options.context);
+      return walker(ast, options.context, frameStack);
     };
   }
 };

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -14,73 +14,93 @@ var instructionDefs = {
   },
   TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, fs) {
     // we are not creating a new tdBody for partials
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
+    var inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   TORNADO_BODY: {
     enter: function enter(node, ctx, fs) {
+      var outer = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.pushTd();
       }
+      var inner = fs.current();
       return {
         type: "open",
-        options: { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }
+        options: { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, fs) {
-      var prev = fs.current();
+      var inner = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.popTd();
       }
+      var outer = fs.current();
       return {
         type: "close",
-        options: { item: node.stackItem, frameStack: prev, ctx: ctx }
+        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     }
   },
   TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
+    var inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   TORNADO_COMMENT: function TORNADO_COMMENT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
+    var inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   HTML_ELEMENT: {
     enter: function enter(node, ctx, fs) {
+      var outer = fs.current();
       fs.pushEl();
+      var inner = fs.current();
       return {
         type: "open",
-        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: fs.current(), ctx: ctx }
+        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, fs) {
       var item = node.stackItem;
       item.state = item.previousState;
-      var prev = fs.current();
+      var inner = fs.current();
       fs.popEl();
+      var outer = fs.current();
       return {
         type: "close",
-        options: { item: item, frameStack: prev, ctx: ctx }
+        options: { item: item, frameStack: [inner, outer], ctx: ctx }
       };
     }
   },
   HTML_ATTRIBUTE: {
     enter: function enter(node, ctx, fs) {
+      var inner = fs.current(),
+          outer = inner;
       return {
         type: "open",
-        options: { item: node.stackItem, frameStack: fs.current(), ctx: ctx }
+        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, fs) {
+      var inner = fs.current(),
+          outer = inner;
       return {
         type: "close",
-        options: { item: node.stackItem, frameStack: fs.current(), ctx: ctx }
+        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     }
   },
   HTML_COMMENT: function HTML_COMMENT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
+    var inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   PLAIN_TEXT: function PLAIN_TEXT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: fs.current(), ctx: ctx }));
+    var inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   }
 };
 

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -14,8 +14,12 @@ var instructionDefs = {
   },
   TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, fs) {
     // we are not creating a new tdBody for partials
-    var inner = fs.current(),
-        outer = inner;
+    var inner = undefined,
+        outer = undefined;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   TORNADO_BODY: {
@@ -23,6 +27,7 @@ var instructionDefs = {
       var outer = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.pushTd();
+        fs.pushPh();
       }
       var inner = fs.current();
       return {
@@ -33,6 +38,7 @@ var instructionDefs = {
     leave: function leave(node, ctx, fs) {
       var inner = fs.current();
       if (node[1].body && node[1].body.length) {
+        fs.popPh();
         fs.popTd();
       }
       var outer = fs.current();
@@ -43,13 +49,21 @@ var instructionDefs = {
     }
   },
   TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx, fs) {
-    var inner = fs.current(),
-        outer = inner;
+    var inner = undefined,
+        outer = undefined;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   TORNADO_COMMENT: function TORNADO_COMMENT(node, ctx, fs) {
-    var inner = fs.current(),
-        outer = inner;
+    var inner = undefined,
+        outer = undefined;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
   },
   HTML_ELEMENT: {
@@ -76,16 +90,18 @@ var instructionDefs = {
   },
   HTML_ATTRIBUTE: {
     enter: function enter(node, ctx, fs) {
-      var inner = fs.current(),
-          outer = inner;
+      var outer = fs.current();
+      fs.pushPh();
+      var inner = fs.current();
       return {
         type: "open",
         options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, fs) {
-      var inner = fs.current(),
-          outer = inner;
+      var inner = fs.current();
+      fs.popPh();
+      var outer = fs.current();
       return {
         type: "close",
         options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }

--- a/dist/compiler/extensions/generateJS.js
+++ b/dist/compiler/extensions/generateJS.js
@@ -166,7 +166,7 @@ var generatorFns = {
   getPlaceholderName: function getPlaceholderName(instruction) {
     var indexPath = instruction.indexPath;
 
-    return "p" + indexPath.join("");
+    return "p" + indexPath;
   },
 
   tdBody_exists: function tdBody_exists(instruction, code) {

--- a/dist/compiler/utils/FrameStack.js
+++ b/dist/compiler/utils/FrameStack.js
@@ -27,17 +27,20 @@ var Stack = function Stack() {
 var FrameStack = function FrameStack() {
   var tdStack = new Stack();
   var elStack = new Stack();
+  var phStack = new Stack();
 
   this.current = function () {
-    return [tdStack.current(), elStack.current()];
+    return [tdStack.current(), elStack.current(), phStack.current()];
   };
   this.pushTd = function () {
     tdStack.enter();
     elStack.jump();
+    phStack.jump();
   };
   this.popTd = function () {
     tdStack.leave();
     elStack.drop();
+    phStack.drop();
   };
   this.pushEl = function () {
     elStack.enter();
@@ -45,9 +48,16 @@ var FrameStack = function FrameStack() {
   this.popEl = function () {
     elStack.leave();
   };
+  this.pushPh = function () {
+    phStack.enter();
+  };
+  this.popPh = function () {
+    phStack.leave();
+  };
   this.reset = function () {
     tdStack = new Stack();
     elStack = new Stack();
+    phStack = new Stack();
   };
   return this;
 };

--- a/dist/compiler/utils/FrameStack.js
+++ b/dist/compiler/utils/FrameStack.js
@@ -1,0 +1,56 @@
+"use strict";
+
+var Stack = function Stack() {
+  var history = [],
+      memory = [];
+  var count = 0;
+  function current() {
+    return history.length ? history[history.length - 1] : null;
+  }
+  this.current = current;
+  this.enter = function (item) {
+    history.push(item || count++);
+  };
+  this.leave = function () {
+    history.pop();
+  };
+  this.jump = function () {
+    memory.push(history);
+    history = [];
+  };
+  this.drop = function () {
+    history = memory.pop();
+  };
+  return this;
+};
+
+var FrameStack = function FrameStack() {
+  var tdStack = new Stack();
+  var elStack = new Stack();
+
+  this.current = function () {
+    return [tdStack.current(), elStack.current()];
+  };
+  this.pushTd = function () {
+    tdStack.enter();
+    elStack.jump();
+  };
+  this.popTd = function () {
+    tdStack.leave();
+    elStack.drop();
+  };
+  this.pushEl = function () {
+    elStack.enter();
+  };
+  this.popEl = function () {
+    elStack.leave();
+  };
+  this.reset = function () {
+    tdStack = new Stack();
+    elStack = new Stack();
+  };
+  return this;
+};
+
+module.exports = FrameStack;
+//# sourceMappingURL=FrameStack.js.map

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -5,7 +5,6 @@ var _slicedToArray = function (arr, i) { if (Array.isArray(arr)) { return arr; }
 var Instruction = function Instruction(action, config) {
   var item = config.item;
   var key = config.key;
-  var indexPath = config.indexPath;
   var frameStack = config.frameStack;
   var state = item.state;
   var node = item.node;
@@ -19,6 +18,7 @@ var Instruction = function Instruction(action, config) {
   var parentTdBody = outer && outer[0] !== null ? outer[0] : 0;
   var elIdx = inner && inner[1] !== null ? inner[1] : 0;
   var parentNodeIdx = outer && outer[1] !== null ? outer[1] : -1;
+  var placeHolderIdx = inner && inner[2] !== null ? inner[2] : 0;
 
   var _node = _slicedToArray(node, 1);
 
@@ -50,7 +50,7 @@ var Instruction = function Instruction(action, config) {
   } else if (nodeType === "HTML_COMMENT" || nodeType === "PLAIN_TEXT") {
     contents = node[1].replace(/'/g, "\\'");
   }
-  indexPath = item.indexPath;
+  var indexPath = "" + placeHolderIdx;
   var instr = {
     action: action,
     nodeType: nodeType,

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -6,6 +6,7 @@ var Instruction = function Instruction(action, config) {
   var item = config.item;
   var key = config.key;
   var indexPath = config.indexPath;
+  var frameStack = config.frameStack;
   var state = item.state;
   var node = item.node;
   var namespace = item.namespace;
@@ -13,7 +14,8 @@ var Instruction = function Instruction(action, config) {
   var blockIndex = item.blockIndex;
   var parentNodeIdx = item.parentNodeIdx;
   var parentTdBody = item.parentTdBody;
-  var tdBody = item.tdBody;
+
+  var tdBody = frameStack[0] === null ? 0 : frameStack[0];
 
   var _node = _slicedToArray(node, 1);
 

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -13,9 +13,11 @@ var Instruction = function Instruction(action, config) {
   var blockName = item.blockName;
   var blockIndex = item.blockIndex;
   var parentNodeIdx = item.parentNodeIdx;
-  var parentTdBody = item.parentTdBody;
 
-  var tdBody = frameStack[0] === null ? 0 : frameStack[0];
+  var inner = frameStack[0] === null ? 0 : frameStack[0];
+  var outer = frameStack[1] === null ? 0 : frameStack[1];
+  var tdBody = inner ? inner[0] : 0;
+  var parentTdBody = outer ? outer[0] : 0;
 
   var _node = _slicedToArray(node, 1);
 

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -19,6 +19,7 @@ var Instruction = function Instruction(action, config) {
   var elIdx = inner && inner[1] !== null ? inner[1] : 0;
   var parentNodeIdx = outer && outer[1] !== null ? outer[1] : -1;
   var placeHolderIdx = inner && inner[2] !== null ? inner[2] : 0;
+  var indexPath = "" + placeHolderIdx;
 
   var _node = _slicedToArray(node, 1);
 
@@ -50,7 +51,6 @@ var Instruction = function Instruction(action, config) {
   } else if (nodeType === "HTML_COMMENT" || nodeType === "PLAIN_TEXT") {
     contents = node[1].replace(/'/g, "\\'");
   }
-  var indexPath = "" + placeHolderIdx;
   var instr = {
     action: action,
     nodeType: nodeType,

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -12,12 +12,13 @@ var Instruction = function Instruction(action, config) {
   var namespace = item.namespace;
   var blockName = item.blockName;
   var blockIndex = item.blockIndex;
-  var parentNodeIdx = item.parentNodeIdx;
 
   var inner = frameStack[0] === null ? 0 : frameStack[0];
   var outer = frameStack[1] === null ? 0 : frameStack[1];
-  var tdBody = inner ? inner[0] : 0;
-  var parentTdBody = outer ? outer[0] : 0;
+  var tdBody = inner && inner[0] !== null ? inner[0] : 0;
+  var parentTdBody = outer && outer[0] !== null ? outer[0] : 0;
+  var elIdx = inner && inner[1] !== null ? inner[1] : 0;
+  var parentNodeIdx = outer && outer[1] !== null ? outer[1] : -1;
 
   var _node = _slicedToArray(node, 1);
 
@@ -67,7 +68,7 @@ var Instruction = function Instruction(action, config) {
     state: state,
     node: node,
     namespace: namespace,
-    elCount: parentNodeIdx + 1
+    elCount: elIdx
   };
   return instr;
 };

--- a/dist/compiler/visitors/visitorKeys.js
+++ b/dist/compiler/visitors/visitorKeys.js
@@ -63,6 +63,7 @@ var visitChildren = function visitChildren(node, visit) {
 
 var visitorKeys = {
   // Current Top level stuff
+  TEMPLATE: visitChildren,
   TORNADO_BODY: visitTornadoBodyChildren,
   TORNADO_PARTIAL: visitTornadoPartialChildren,
   HTML_ELEMENT: visitHtmlElementChildren,

--- a/dist/parser.js
+++ b/dist/parser.js
@@ -33,7 +33,7 @@ module.exports = (function() {
         peg$startRuleFunction  = peg$parsestart,
 
         peg$c0 = function(n) {
-            return ['TORNADO_BODY'].concat([{name: null, type: 'bodies', body: n}]);
+            return ['TEMPLATE', ['TORNADO_BODY'].concat([{name: null, type: 'bodies', body: n}])];
           },
         peg$c1 = [],
         peg$c2 = peg$FAILED,

--- a/src/compiler/context.js
+++ b/src/compiler/context.js
@@ -41,7 +41,7 @@ const STATES = {
 };
 
 let Context = function(results) {
-  let nodeStack = [{indexPath: []}];
+  let nodeStack = [{}];
   const defaultState = STATES.OUTER_SPACE;
 
   let context = {
@@ -72,10 +72,7 @@ let Context = function(results) {
     stack: {
       push(node, index, method) {
         let nodeType = node[0];
-        let parentIndexPath = this.stack.peek('indexPath');
         let isTornadoBody = (nodeType === 'TORNADO_BODY');
-        let isParentTdBody = (this.stack.peek('nodeType') === 'TORNADO_BODY');
-        let isAttr = (nodeType === 'HTML_ATTRIBUTE');
         let namespace = '';
         let blockName, blockIndex;
         if (nodeType === 'HTML_ELEMENT') {
@@ -84,14 +81,7 @@ let Context = function(results) {
         if (nodeType === 'HTML_ELEMENT' || nodeType === 'HTML_ATTRIBUTE') {
           namespace = this.getCurrentNamespace(namespace);
         }
-        let indexPath = parentIndexPath.slice(0);
         let state = this.getCurrentState();
-        if (isParentTdBody) {
-          indexPath = [];
-        }
-        if (!isAttr) {
-          indexPath.push(index);
-        }
 
         if (isTornadoBody) {
           let bodyType = node[1].type;
@@ -113,7 +103,6 @@ let Context = function(results) {
         let stackItem = {
           node,
           nodeType,
-          indexPath,
           state,
           previousState: this.stack.peek('state'),
           blockName,

--- a/src/compiler/context.js
+++ b/src/compiler/context.js
@@ -42,32 +42,11 @@ const STATES = {
 
 let Context = function(results) {
   let nodeStack = [{indexPath: []}];
-  // let refCount;
-  let tornadoBodiesPointer = -1;
   const defaultState = STATES.OUTER_SPACE;
 
   let context = {
     blocks: {},
     state: defaultState,
-    getCurrentTdBody(nodeType) {
-      if (nodeType === 'TORNADO_BODY') {
-        return tornadoBodiesPointer;
-      } else {
-        return this.stack.peek('tdBody');
-      }
-    },
-    getElContainer() {
-      let container = this.stack.peek('parentNodeIdx');
-      let nodeType = this.stack.peek('nodeType');
-      if (nodeType === 'TORNADO_BODY') {
-        return -1;
-      } else if (nodeType === 'HTML_ELEMENT') {
-        return container + 1;
-      }
-    },
-    incrementCurrentTdBody() {
-      tornadoBodiesPointer++;
-    },
     pushInstruction(instruction) {
       results.instructions.push(instruction);
     },
@@ -98,7 +77,7 @@ let Context = function(results) {
         let isParentTdBody = (this.stack.peek('nodeType') === 'TORNADO_BODY');
         let isAttr = (nodeType === 'HTML_ATTRIBUTE');
         let namespace = '';
-        let parentTdBody, blockName, blockIndex;
+        let blockName, blockIndex;
         if (nodeType === 'HTML_ELEMENT') {
           namespace = this.getNamespaceFromNode(node);
         }
@@ -116,10 +95,6 @@ let Context = function(results) {
 
         if (isTornadoBody) {
           let bodyType = node[1].type;
-          parentTdBody = this.stack.peek('tdBody');
-          if (node[1].body && node[1].body.length) {
-            this.incrementCurrentTdBody();
-          }
           if (bodyType === 'block' || bodyType === 'inlinePartial') {
             blockName = node[1].key.join('.');
             if (bodyType === 'block') {
@@ -143,10 +118,7 @@ let Context = function(results) {
           previousState: this.stack.peek('state'),
           blockName,
           blockIndex,
-          namespace,
-          tdBody: this.getCurrentTdBody(nodeType),
-          parentTdBody,
-          parentNodeIdx: this.getElContainer()
+          namespace
         };
         nodeStack.push(stackItem);
         method(stackItem, this);

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -10,8 +10,11 @@ let instructionDefs = {
   },
   TORNADO_PARTIAL(node, ctx, fs) {
     // we are not creating a new tdBody for partials
-    let inner = fs.current(),
-        outer = inner;
+    let inner, outer;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   TORNADO_BODY: {
@@ -19,6 +22,7 @@ let instructionDefs = {
       let outer = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.pushTd();
+        fs.pushPh();
       }
       let inner = fs.current();
       return {
@@ -29,6 +33,7 @@ let instructionDefs = {
     leave(node, ctx, fs) {
       let inner = fs.current();
       if (node[1].body && node[1].body.length) {
+        fs.popPh();
         fs.popTd();
       }
       let outer = fs.current();
@@ -39,13 +44,19 @@ let instructionDefs = {
     }
   },
   TORNADO_REFERENCE(node, ctx, fs) {
-    let inner = fs.current(),
-        outer = inner;
+    let inner, outer;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   TORNADO_COMMENT(node, ctx, fs) {
-    let inner = fs.current(),
-        outer = inner;
+    let inner, outer;
+    fs.pushPh();
+    inner = fs.current();
+    fs.popPh();
+    outer = fs.current();
     ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   HTML_ELEMENT: {
@@ -72,16 +83,18 @@ let instructionDefs = {
   },
   HTML_ATTRIBUTE: {
     enter(node, ctx, fs) {
-      let inner = fs.current(),
-          outer = inner;
+      let outer = fs.current();
+      fs.pushPh();
+      let inner = fs.current();
       return {
         type: 'open',
         options: {item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     },
     leave(node, ctx, fs) {
-      let inner = fs.current(),
-          outer = inner;
+      let inner = fs.current();
+      fs.popPh();
+      let outer = fs.current();
       return {
         type: 'close',
         options: {item: node.stackItem, frameStack: [inner, outer], ctx}

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -10,73 +10,93 @@ let instructionDefs = {
   },
   TORNADO_PARTIAL(node, ctx, fs) {
     // we are not creating a new tdBody for partials
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}));
+    let inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   TORNADO_BODY: {
     enter(node, ctx, fs) {
+      let outer = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.pushTd();
       }
+      let inner = fs.current();
       return {
         type: 'open',
-        options: {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}
+        options: {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     },
     leave(node, ctx, fs) {
-      let prev = fs.current();
+      let inner = fs.current();
       if (node[1].body && node[1].body.length) {
         fs.popTd();
       }
+      let outer = fs.current();
       return {
         type: 'close',
-        options: {item: node.stackItem, frameStack: prev, ctx}
+        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     }
   },
   TORNADO_REFERENCE(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}));
+    let inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   TORNADO_COMMENT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
+    let inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   HTML_ELEMENT: {
     enter(node, ctx, fs) {
+      let outer = fs.current();
       fs.pushEl();
+      let inner = fs.current();
       return {
         type: 'open',
-        options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: fs.current(), ctx}
+        options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     },
     leave(node, ctx, fs){
       let item = node.stackItem;
       item.state = item.previousState;
-      let prev = fs.current();
+      let inner = fs.current();
       fs.popEl();
+      let outer = fs.current();
       return {
         type: 'close',
-        options: {item, frameStack: prev, ctx}
+        options: {item, frameStack: [inner, outer], ctx}
       };
     }
   },
   HTML_ATTRIBUTE: {
     enter(node, ctx, fs) {
+      let inner = fs.current(),
+          outer = inner;
       return {
         type: 'open',
-        options: {item: node.stackItem, frameStack: fs.current(), ctx}
+        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     },
     leave(node, ctx, fs) {
+      let inner = fs.current(),
+          outer = inner;
       return {
         type: 'close',
-        options: {item: node.stackItem, frameStack: fs.current(), ctx}
+        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
       };
     }
   },
   HTML_COMMENT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
+    let inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
   },
   PLAIN_TEXT(node, ctx, fs) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
+    let inner = fs.current(),
+        outer = inner;
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
   }
 };
 

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -2,66 +2,81 @@
 
 import visitor from '../visitors/visitor';
 import Instruction from '../utils/Instruction';
+import FrameStack from '../utils/FrameStack';
 
 let instructionDefs = {
-  TORNADO_PARTIAL(node, ctx) {
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, ctx}));
+  TEMPLATE(node, ctx, fs) {
+    fs.reset();
+  },
+  TORNADO_PARTIAL(node, ctx, fs) {
+    // we are not creating a new tdBody for partials
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}));
   },
   TORNADO_BODY: {
-    enter(node, ctx) {
+    enter(node, ctx, fs) {
+      if (node[1].body && node[1].body.length) {
+        fs.pushTd();
+      }
       return {
         type: 'open',
-        options: {key: node[1].key, item: node.stackItem, ctx}
+        options: {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}
       };
     },
-    leave(node, ctx) {
+    leave(node, ctx, fs) {
+      let prev = fs.current();
+      if (node[1].body && node[1].body.length) {
+        fs.popTd();
+      }
       return {
         type: 'close',
-        options: {item: node.stackItem, ctx}
+        options: {item: node.stackItem, frameStack: prev, ctx}
       };
     }
   },
-  TORNADO_REFERENCE(node, ctx) {
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, ctx}));
+  TORNADO_REFERENCE(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: fs.current(), ctx}));
   },
-  TORNADO_COMMENT(node, ctx) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, ctx}));
+  TORNADO_COMMENT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
   },
   HTML_ELEMENT: {
-    enter(node, ctx) {
+    enter(node, ctx, fs) {
+      fs.pushEl();
       return {
         type: 'open',
-        options: {key: node[1].tag_info.key, item: node.stackItem, ctx}
+        options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: fs.current(), ctx}
       };
     },
-    leave(node, ctx){
-      var item = node.stackItem;
+    leave(node, ctx, fs){
+      let item = node.stackItem;
       item.state = item.previousState;
+      let prev = fs.current();
+      fs.popEl();
       return {
         type: 'close',
-        options: {item, ctx}
+        options: {item, frameStack: prev, ctx}
       };
     }
   },
   HTML_ATTRIBUTE: {
-    enter(node, ctx) {
+    enter(node, ctx, fs) {
       return {
         type: 'open',
-        options: {item: node.stackItem, ctx}
+        options: {item: node.stackItem, frameStack: fs.current(), ctx}
       };
     },
-    leave(node, ctx) {
+    leave(node, ctx, fs) {
       return {
         type: 'close',
-        options: {item: node.stackItem, ctx}
+        options: {item: node.stackItem, frameStack: fs.current(), ctx}
       };
     }
   },
-  HTML_COMMENT(node, ctx) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, ctx}));
+  HTML_COMMENT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
   },
-  PLAIN_TEXT(node, ctx) {
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, ctx}));
+  PLAIN_TEXT(node, ctx, fs) {
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: fs.current(), ctx}));
   }
 };
 
@@ -72,12 +87,14 @@ let buildInstructions = {
       this.instructionDefs[name] = instruction;
     } else {
       let instructionDef = {
-        enter: instruction.enter ? (node, ctx) => {
-          let enter = instruction.enter(node, ctx);
+        enter: instruction.enter ? function() {
+          let ctx = arguments[1];
+          let enter = instruction.enter.apply(null, arguments);
           ctx.pushInstruction(new Instruction(enter.type, enter.options));
         } : null,
-        leave: instruction.leave ? (node, ctx) => {
-          let leave = instruction.leave(node, ctx);
+        leave: instruction.leave ? function() {
+          let ctx = arguments[1];
+          let leave = instruction.leave.apply(null, arguments);
           ctx.pushInstruction(new Instruction(leave.type, leave.options));
         } : null
       };
@@ -90,9 +107,10 @@ let buildInstructions = {
     });
   },
   generateInstructions() {
+    let frameStack = new FrameStack();
     let walker = visitor.build(this.instructionDefs);
     return function(ast, options) {
-      return walker(ast, options.context);
+      return walker(ast, options.context, frameStack);
     };
   }
 };

--- a/src/compiler/extensions/generateJS.js
+++ b/src/compiler/extensions/generateJS.js
@@ -134,7 +134,7 @@ let generatorFns = {
 
   getPlaceholderName(instruction) {
     let {indexPath} = instruction;
-    return `p${indexPath.join('')}`;
+    return `p${indexPath}`;
   },
 
   tdBody_exists(instruction, code) {

--- a/src/compiler/utils/FrameStack.js
+++ b/src/compiler/utils/FrameStack.js
@@ -1,0 +1,54 @@
+let Stack = function() {
+  let history = [],
+      memory = [];
+  let count = 0;
+  function current() {
+    return history.length ? history[history.length - 1] : null;
+  }
+  this.current = current;
+  this.enter = function(item) {
+    history.push(item || count++);
+  };
+  this.leave = function() {
+    history.pop();
+  };
+  this.jump = function() {
+    memory.push(history);
+    history = [];
+  };
+  this.drop = function() {
+    history = memory.pop();
+  };
+  return this;
+};
+
+let FrameStack = function() {
+  let tdStack = new Stack();
+  let elStack = new Stack();
+
+  this.current = function() {
+    return [tdStack.current(), elStack.current()];
+  };
+  this.pushTd = function() {
+    tdStack.enter();
+    elStack.jump();
+  };
+  this.popTd = function() {
+    tdStack.leave();
+    elStack.drop();
+  };
+  this.pushEl = function() {
+    elStack.enter();
+  };
+  this.popEl = function() {
+    elStack.leave();
+  };
+  this.reset = function() {
+    tdStack = new Stack();
+    elStack = new Stack();
+  };
+  return this;
+};
+
+
+module.exports = FrameStack;

--- a/src/compiler/utils/FrameStack.js
+++ b/src/compiler/utils/FrameStack.js
@@ -25,17 +25,20 @@ let Stack = function() {
 let FrameStack = function() {
   let tdStack = new Stack();
   let elStack = new Stack();
+  let phStack = new Stack();
 
   this.current = function() {
-    return [tdStack.current(), elStack.current()];
+    return [tdStack.current(), elStack.current(), phStack.current()];
   };
   this.pushTd = function() {
     tdStack.enter();
     elStack.jump();
+    phStack.jump();
   };
   this.popTd = function() {
     tdStack.leave();
     elStack.drop();
+    phStack.drop();
   };
   this.pushEl = function() {
     elStack.enter();
@@ -43,9 +46,16 @@ let FrameStack = function() {
   this.popEl = function() {
     elStack.leave();
   };
+  this.pushPh = function() {
+    phStack.enter();
+  };
+  this.popPh = function() {
+    phStack.leave();
+  };
   this.reset = function() {
     tdStack = new Stack();
     elStack = new Stack();
+    phStack = new Stack();
   };
   return this;
 };

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,10 +1,12 @@
 let Instruction = function(action, config) {
   let {item, key, indexPath, frameStack} = config;
-  let {state, node, namespace, blockName, blockIndex, parentNodeIdx} = item;
+  let {state, node, namespace, blockName, blockIndex} = item;
   let inner = frameStack[0] === null ? 0 : frameStack[0];
   let outer = frameStack[1] === null ? 0 : frameStack[1];
-  let tdBody = inner ? inner[0] : 0;
-  let parentTdBody = outer ? outer[0] : 0;
+  let tdBody = ( inner && inner[0] !== null ) ? inner[0] : 0;
+  let parentTdBody = ( outer && outer[0] !== null ) ? outer[0] : 0;
+  let elIdx = ( inner && inner[1] !== null ) ? inner[1] : 0;
+  let parentNodeIdx = ( outer && outer[1] !== null ) ? outer[1] : -1;
 
   let [nodeType] = node;
   let contents;
@@ -48,7 +50,7 @@ let Instruction = function(action, config) {
     state,
     node,
     namespace,
-    elCount: parentNodeIdx + 1
+    elCount: elIdx
   };
   return instr;
 };

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,7 +1,11 @@
 let Instruction = function(action, config) {
   let {item, key, indexPath, frameStack} = config;
-  let {state, node, namespace, blockName, blockIndex, parentNodeIdx, parentTdBody} = item;
-  let tdBody = frameStack[0] === null ? 0 : frameStack[0];
+  let {state, node, namespace, blockName, blockIndex, parentNodeIdx} = item;
+  let inner = frameStack[0] === null ? 0 : frameStack[0];
+  let outer = frameStack[1] === null ? 0 : frameStack[1];
+  let tdBody = inner ? inner[0] : 0;
+  let parentTdBody = outer ? outer[0] : 0;
+
   let [nodeType] = node;
   let contents;
   let parentNodeName = (parentNodeIdx === -1) ? 'frag' : `el${parentNodeIdx}`;

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -8,6 +8,7 @@ let Instruction = function(action, config) {
   let elIdx = ( inner && inner[1] !== null ) ? inner[1] : 0;
   let parentNodeIdx = ( outer && outer[1] !== null ) ? outer[1] : -1;
   let placeHolderIdx = (inner && inner[2] !== null) ? inner[2] : 0;
+  let indexPath = '' + placeHolderIdx;
 
   let [nodeType] = node;
   let contents;
@@ -33,7 +34,6 @@ let Instruction = function(action, config) {
   } else if (nodeType === 'HTML_COMMENT' || nodeType === 'PLAIN_TEXT') {
     contents = node[1].replace(/'/g, "\\'");
   }
-  let indexPath = '' + placeHolderIdx;
   let instr = {
     action,
     nodeType,

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,5 +1,5 @@
 let Instruction = function(action, config) {
-  let {item, key, indexPath, frameStack} = config;
+  let {item, key, frameStack} = config;
   let {state, node, namespace, blockName, blockIndex} = item;
   let inner = frameStack[0] === null ? 0 : frameStack[0];
   let outer = frameStack[1] === null ? 0 : frameStack[1];
@@ -7,6 +7,7 @@ let Instruction = function(action, config) {
   let parentTdBody = ( outer && outer[0] !== null ) ? outer[0] : 0;
   let elIdx = ( inner && inner[1] !== null ) ? inner[1] : 0;
   let parentNodeIdx = ( outer && outer[1] !== null ) ? outer[1] : -1;
+  let placeHolderIdx = (inner && inner[2] !== null) ? inner[2] : 0;
 
   let [nodeType] = node;
   let contents;
@@ -32,7 +33,7 @@ let Instruction = function(action, config) {
   } else if (nodeType === 'HTML_COMMENT' || nodeType === 'PLAIN_TEXT') {
     contents = node[1].replace(/'/g, "\\'");
   }
-  indexPath = item.indexPath;
+  let indexPath = '' + placeHolderIdx;
   let instr = {
     action,
     nodeType,

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,6 +1,7 @@
 let Instruction = function(action, config) {
-  let {item, key, indexPath} = config;
-  let {state, node, namespace, blockName, blockIndex, parentNodeIdx, parentTdBody, tdBody} = item;
+  let {item, key, indexPath, frameStack} = config;
+  let {state, node, namespace, blockName, blockIndex, parentNodeIdx, parentTdBody} = item;
+  let tdBody = frameStack[0] === null ? 0 : frameStack[0];
   let [nodeType] = node;
   let contents;
   let parentNodeName = (parentNodeIdx === -1) ? 'frag' : `el${parentNodeIdx}`;

--- a/src/compiler/visitors/visitorKeys.js
+++ b/src/compiler/visitors/visitorKeys.js
@@ -63,6 +63,7 @@ let visitChildren = function(node, visit) {
 
 let visitorKeys = {
   // Current Top level stuff
+  TEMPLATE: visitChildren,
   TORNADO_BODY: visitTornadoBodyChildren,
   TORNADO_PARTIAL: visitTornadoPartialChildren,
   HTML_ELEMENT: visitHtmlElementChildren,

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -13,7 +13,7 @@
 
 start
   = n:nodes {
-    return ['TORNADO_BODY'].concat([{name: null, type: 'bodies', body: n}]);
+    return ['TEMPLATE', ['TORNADO_BODY'].concat([{name: null, type: 'bodies', body: n}])];
   }
 
 nodes


### PR DESCRIPTION
- introduce a framestack object which keeps track of tdBody, elIndex/count and placeholders
- have the instructions increment the framestack values to represent where we are within tornado/elements/placeholders
- remove (now) unused code from context

the value of the framestack inside of instructions being `[inner, outer]` might make more sense as `[before, after]` this might change when we eventually rejigger the generateJS step.
#### Next steps
- `blockIndex` can prolly move into this as well
- Not sure if It make sense that attributes create a placeholder seems we're doing some tricky stuff with  `hasTornadoRef`
