### PR TITLE
Update debugger to use new visitor API

### DIFF
--- a/dist/compiler/extensions/debugger.js
+++ b/dist/compiler/extensions/debugger.js
@@ -4,12 +4,10 @@
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 
-var visitor = _interopRequire(require("../visitor"));
+var visitor = _interopRequire(require("../visitors/visitor"));
 
 var generatedWalker = visitor.build({
-  TORNADO_BODY: function TORNADO_BODY(item) {
-    var node = item.node;
-
+  TORNADO_BODY: function TORNADO_BODY(node) {
     var nodeInfo = node[1];
     if (nodeInfo.type === "helper" && nodeInfo.key.join("") === "debugger") {
       node[0] = "TORNADO_DEBUGGER";
@@ -23,10 +21,12 @@ var debuggerExtension = {
   }],
   instructions: {
     TORNADO_DEBUGGER: {
-      enter: function enter(item, ctx) {
+      enter: function enter(node, ctx, frameStack) {
+        var inner = frameStack.current(),
+            outer = inner;
         return {
           type: "insert",
-          options: { key: item.node[1].key, item: item, ctx: ctx }
+          options: { key: node[1].key, frameStack: [inner, outer], item: node.stackItem, ctx: ctx }
         };
       }
     }

--- a/src/compiler/extensions/debugger.js
+++ b/src/compiler/extensions/debugger.js
@@ -1,11 +1,10 @@
 /* eslint camelcase: 0 */
 
 'use strict';
-import visitor from '../visitor';
+import visitor from '../visitors/visitor';
 
 let generatedWalker = visitor.build({
-  TORNADO_BODY(item) {
-    let {node} = item;
+  TORNADO_BODY(node) {
     let nodeInfo = node[1];
     if (nodeInfo.type === 'helper' && nodeInfo.key.join('') === 'debugger') {
       node[0] = 'TORNADO_DEBUGGER';
@@ -19,10 +18,12 @@ let debuggerExtension = {
   }],
   instructions: {
     TORNADO_DEBUGGER: {
-      enter(item, ctx) {
+      enter(node, ctx, frameStack) {
+        let inner = frameStack.current(),
+            outer = inner;
         return {
           type: 'insert',
-          options: {key: item.node[1].key, item, ctx}
+          options: {key: node[1].key, frameStack: [inner, outer], item: node.stackItem, ctx}
         };
       }
     }


### PR DESCRIPTION
Based on recent changes in visitor and the instruction builder (with
frameStacks) the debugger extension was no longer working. This update
fixes the debugger helper and improves the build instruction's
`addInstruction` API to allow extension-defined instructions to include
only an `enter` or `leave` method.
