### PR TITLE
Use a state for Attr, drop context.state, use setState and getStates instead

### DIFF
--- a/dist/compiler/context.js
+++ b/dist/compiler/context.js
@@ -32,32 +32,12 @@ if (!Object.assign) {
   });
 }
 
-var STATES = {
-  OUTER_SPACE: "OUTER_SPACE",
-  HTML_TAG: "HTML_TAG",
-  HTML_BODY: "HTML_BODY",
-  HTML_ATTRIBUTE: "HTML_ATTRIBUTE",
-  ESCAPABLE_RAW: "ESCAPABLE_RAW",
-  TORNADO_TAG: "TORNADO_TAG",
-  TORNADO_BODY: "TORNADO_BODY"
-};
-
 var Context = function Context(results) {
   var nodeStack = [{}];
-  var defaultState = STATES.OUTER_SPACE;
 
   var context = {
-    state: defaultState,
     pushInstruction: function pushInstruction(instruction) {
       results.instructions.push(instruction);
-    },
-    getCurrentState: function getCurrentState() {
-      var state = STATES[this.stack.peek("nodeType")] || this.stack.peek("state");
-      if (!state) {
-        return STATES.OUTER_SPACE;
-      } else {
-        return state;
-      }
     },
     getNamespaceFromNode: function getNamespaceFromNode(node) {
       var nodeInfo = node[1].tag_info;
@@ -82,16 +62,10 @@ var Context = function Context(results) {
         if (nodeType === "HTML_ELEMENT" || nodeType === "HTML_ATTRIBUTE") {
           namespace = this.getCurrentNamespace(namespace);
         }
-        var state = this.getCurrentState();
 
-        if (node[1].escapableRaw) {
-          state = STATES.ESCAPABLE_RAW;
-        }
         var stackItem = {
           node: node,
           nodeType: nodeType,
-          state: state,
-          previousState: this.stack.peek("state"),
           namespace: namespace
         };
         nodeStack.push(stackItem);

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -8,13 +8,27 @@ var Instruction = _interopRequire(require("../utils/Instruction"));
 
 var FrameStack = _interopRequire(require("../utils/FrameStack"));
 
+var Stack = _interopRequire(require("../utils/Stack"));
+
 function noop() {}
 
+function enterAll(states, stateStack) {
+  states.forEach(function (s) {
+    stateStack.enter(s);
+  });
+}
+function leaveAll(states, stateStack) {
+  states.forEach(function (s) {
+    stateStack.leave(s);
+  });
+}
+
 var instructionDefs = {
-  TEMPLATE: function TEMPLATE(node, ctx, frameStack) {
+  TEMPLATE: function TEMPLATE(node, ctx, frameStack, stateStack) {
+    stateStack.clear();
     frameStack.reset();
   },
-  TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, frameStack) {
+  TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, frameStack, stateStack) {
     // we are not creating a new tdBody for partials
     var child = undefined,
         parent = undefined;
@@ -22,32 +36,36 @@ var instructionDefs = {
     child = frameStack.current();
     frameStack.popPh();
     parent = frameStack.current();
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }));
   },
   TORNADO_BODY: {
-    enter: function enter(node, ctx, frameStack) {
+    enter: function enter(node, ctx, frameStack, stateStack) {
       var parent = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.pushTd();
         frameStack.pushPh();
       }
       var child = frameStack.current();
-      return {
+      var out = {
         type: "open",
-        options: { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }
+        options: { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      enterAll(this.getStates(node, "enter"), stateStack);
+      return out;
     },
-    leave: function leave(node, ctx, frameStack) {
+    leave: function leave(node, ctx, frameStack, stateStack) {
       var child = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.popPh();
         frameStack.popTd();
       }
       var parent = frameStack.current();
-      return {
+      leaveAll(this.getStates(node, "leave"), stateStack);
+      var out = {
         type: "close",
-        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      return out;
     }
   },
   TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx, frameStack) {
@@ -69,47 +87,55 @@ var instructionDefs = {
     ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   },
   HTML_ELEMENT: {
-    enter: function enter(node, ctx, frameStack) {
+    enter: function enter(node, ctx, frameStack, stateStack) {
       var parent = frameStack.current();
       frameStack.pushEl();
       var child = frameStack.current();
-      return {
+      var out = {
         type: "open",
-        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }
+        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      enterAll(this.getStates(node, "enter"), stateStack);
+      return out;
     },
-    leave: function leave(node, ctx, frameStack) {
+    leave: function leave(node, ctx, frameStack, stateStack) {
       var item = node.stackItem;
       item.state = item.previousState;
       var child = frameStack.current();
       frameStack.popEl();
       var parent = frameStack.current();
-      return {
+      leaveAll(this.getStates(node, "leave"), stateStack);
+      var out = {
         type: "close",
-        options: { item: item, frameStack: [child, parent], ctx: ctx }
+        options: { item: item, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      return out;
     }
   },
   HTML_ATTRIBUTE: {
-    enter: function enter(node, ctx, frameStack) {
+    enter: function enter(node, ctx, frameStack, stateStack) {
       var parent = frameStack.current();
       frameStack.pushAttr();
       frameStack.pushPh();
       var child = frameStack.current();
-      return {
+      var out = {
         type: "open",
-        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      enterAll(this.getStates(node, "enter"), stateStack);
+      return out;
     },
-    leave: function leave(node, ctx, frameStack) {
+    leave: function leave(node, ctx, frameStack, stateStack) {
       var child = frameStack.current();
       frameStack.popPh();
       frameStack.popAttr();
       var parent = frameStack.current();
-      return {
+      leaveAll(this.getStates(node, "leave"), stateStack);
+      var out = {
         type: "close",
-        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
+      return out;
     }
   },
   HTML_COMMENT: function HTML_COMMENT(node, ctx, frameStack) {
@@ -133,12 +159,12 @@ var buildInstructions = {
       var instructionDef = {
         enter: instruction.enter ? function () {
           var ctx = arguments[1];
-          var enter = instruction.enter.apply(null, arguments);
+          var enter = instruction.enter.apply(this, arguments);
           ctx.pushInstruction(new Instruction(enter.type, enter.options));
         } : noop,
         leave: instruction.leave ? function () {
           var ctx = arguments[1];
-          var leave = instruction.leave.apply(null, arguments);
+          var leave = instruction.leave.apply(this, arguments);
           ctx.pushInstruction(new Instruction(leave.type, leave.options));
         } : noop
       };
@@ -154,9 +180,10 @@ var buildInstructions = {
   },
   generateInstructions: function generateInstructions() {
     var frameStack = new FrameStack();
+    var stateStack = new Stack();
     var walker = visitor.build(this.instructionDefs);
     return function (ast, options) {
-      return walker(ast, options.context, frameStack);
+      return walker(ast, options.context, frameStack, stateStack);
     };
   }
 };

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -16,109 +16,111 @@ var instructionDefs = {
   },
   TORNADO_PARTIAL: function TORNADO_PARTIAL(node, ctx, frameStack) {
     // we are not creating a new tdBody for partials
-    var inner = undefined,
-        outer = undefined;
+    var child = undefined,
+        parent = undefined;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   },
   TORNADO_BODY: {
     enter: function enter(node, ctx, frameStack) {
-      var outer = frameStack.current();
+      var parent = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.pushTd();
         frameStack.pushPh();
       }
-      var inner = frameStack.current();
+      var child = frameStack.current();
       return {
         type: "open",
-        options: { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
+        options: { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, frameStack) {
-      var inner = frameStack.current();
+      var child = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.popPh();
         frameStack.popTd();
       }
-      var outer = frameStack.current();
+      var parent = frameStack.current();
       return {
         type: "close",
-        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
       };
     }
   },
   TORNADO_REFERENCE: function TORNADO_REFERENCE(node, ctx, frameStack) {
-    var inner = undefined,
-        outer = undefined;
+    var child = undefined,
+        parent = undefined;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction("insert", { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   },
   TORNADO_COMMENT: function TORNADO_COMMENT(node, ctx, frameStack) {
-    var inner = undefined,
-        outer = undefined;
+    var child = undefined,
+        parent = undefined;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   },
   HTML_ELEMENT: {
     enter: function enter(node, ctx, frameStack) {
-      var outer = frameStack.current();
+      var parent = frameStack.current();
       frameStack.pushEl();
-      var inner = frameStack.current();
+      var child = frameStack.current();
       return {
         type: "open",
-        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
+        options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, frameStack) {
       var item = node.stackItem;
       item.state = item.previousState;
-      var inner = frameStack.current();
+      var child = frameStack.current();
       frameStack.popEl();
-      var outer = frameStack.current();
+      var parent = frameStack.current();
       return {
         type: "close",
-        options: { item: item, frameStack: [inner, outer], ctx: ctx }
+        options: { item: item, frameStack: [child, parent], ctx: ctx }
       };
     }
   },
   HTML_ATTRIBUTE: {
     enter: function enter(node, ctx, frameStack) {
-      var outer = frameStack.current();
+      var parent = frameStack.current();
+      frameStack.pushAttr();
       frameStack.pushPh();
-      var inner = frameStack.current();
+      var child = frameStack.current();
       return {
         type: "open",
-        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
       };
     },
     leave: function leave(node, ctx, frameStack) {
-      var inner = frameStack.current();
+      var child = frameStack.current();
       frameStack.popPh();
-      var outer = frameStack.current();
+      frameStack.popAttr();
+      var parent = frameStack.current();
       return {
         type: "close",
-        options: { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }
+        options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx }
       };
     }
   },
   HTML_COMMENT: function HTML_COMMENT(node, ctx, frameStack) {
-    var inner = frameStack.current(),
-        outer = inner;
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
+    var child = frameStack.current(),
+        parent = child;
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   },
   PLAIN_TEXT: function PLAIN_TEXT(node, ctx, frameStack) {
-    var inner = frameStack.current(),
-        outer = inner;
-    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [inner, outer], ctx: ctx }));
+    var child = frameStack.current(),
+        parent = child;
+    ctx.pushInstruction(new Instruction("insert", { item: node.stackItem, frameStack: [child, parent], ctx: ctx }));
   }
 };
 

--- a/dist/compiler/extensions/buildInstructions.js
+++ b/dist/compiler/extensions/buildInstructions.js
@@ -50,7 +50,7 @@ var instructionDefs = {
         type: "open",
         options: { key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
-      enterAll(this.getStates(node, "enter"), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave: function leave(node, ctx, frameStack, stateStack) {
@@ -60,7 +60,7 @@ var instructionDefs = {
         frameStack.popTd();
       }
       var parent = frameStack.current();
-      leaveAll(this.getStates(node, "leave"), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       var out = {
         type: "close",
         options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
@@ -95,7 +95,7 @@ var instructionDefs = {
         type: "open",
         options: { key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
-      enterAll(this.getStates(node, "enter"), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave: function leave(node, ctx, frameStack, stateStack) {
@@ -104,7 +104,7 @@ var instructionDefs = {
       var child = frameStack.current();
       frameStack.popEl();
       var parent = frameStack.current();
-      leaveAll(this.getStates(node, "leave"), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       var out = {
         type: "close",
         options: { item: item, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
@@ -122,7 +122,7 @@ var instructionDefs = {
         type: "open",
         options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }
       };
-      enterAll(this.getStates(node, "enter"), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave: function leave(node, ctx, frameStack, stateStack) {
@@ -130,7 +130,7 @@ var instructionDefs = {
       frameStack.popPh();
       frameStack.popAttr();
       var parent = frameStack.current();
-      leaveAll(this.getStates(node, "leave"), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       var out = {
         type: "close",
         options: { item: node.stackItem, frameStack: [child, parent], ctx: ctx, stateStack: stateStack }

--- a/dist/compiler/extensions/debugger.js
+++ b/dist/compiler/extensions/debugger.js
@@ -22,11 +22,11 @@ var debuggerExtension = {
   instructions: {
     TORNADO_DEBUGGER: {
       enter: function enter(node, ctx, frameStack) {
-        var inner = frameStack.current(),
-            outer = inner;
+        var child = frameStack.current(),
+            parent = child;
         return {
           type: "insert",
-          options: { key: node[1].key, frameStack: [inner, outer], item: node.stackItem, ctx: ctx }
+          options: { key: node[1].key, frameStack: [child, parent], item: node.stackItem, ctx: ctx }
         };
       }
     }

--- a/dist/compiler/extensions/escapableRaw.js
+++ b/dist/compiler/extensions/escapableRaw.js
@@ -4,12 +4,22 @@ var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["defau
 
 var visitor = _interopRequire(require("../visitors/visitor"));
 
+var STATES = require("../utils/builder").STATES;
+
 var escapableRawEls = ["textarea", "title"];
 var generatedWalker = visitor.build({
-  HTML_ELEMENT: function HTML_ELEMENT(node) {
-    var key = node[1].tag_info.key;
-    if (escapableRawEls.indexOf(key) > -1) {
-      node[1].escapableRaw = true;
+  HTML_ELEMENT: {
+    enter: function enter(node) {
+      var key = node[1].tag_info.key;
+      if (escapableRawEls.indexOf(key) > -1) {
+        this.enterState(node, STATES.ESCAPABLE_RAW);
+      }
+    },
+    leave: function leave(node) {
+      var key = node[1].tag_info.key;
+      if (escapableRawEls.indexOf(key) > -1) {
+        this.leaveState(node, STATES.ESCAPABLE_RAW);
+      }
     }
   }
 });

--- a/dist/compiler/extensions/escapableRaw.js
+++ b/dist/compiler/extensions/escapableRaw.js
@@ -8,18 +8,10 @@ var STATES = require("../utils/builder").STATES;
 
 var escapableRawEls = ["textarea", "title"];
 var generatedWalker = visitor.build({
-  HTML_ELEMENT: {
-    enter: function enter(node) {
-      var key = node[1].tag_info.key;
-      if (escapableRawEls.indexOf(key) > -1) {
-        this.enterState(node, STATES.ESCAPABLE_RAW);
-      }
-    },
-    leave: function leave(node) {
-      var key = node[1].tag_info.key;
-      if (escapableRawEls.indexOf(key) > -1) {
-        this.leaveState(node, STATES.ESCAPABLE_RAW);
-      }
+  HTML_ELEMENT: function HTML_ELEMENT(node) {
+    var key = node[1].tag_info.key;
+    if (escapableRawEls.indexOf(key) > -1) {
+      this.setState(node, STATES.ESCAPABLE_RAW);
     }
   }
 });

--- a/dist/compiler/extensions/generateJS.js
+++ b/dist/compiler/extensions/generateJS.js
@@ -17,9 +17,10 @@ var generatorFns = {
   insert_TORNADO_PARTIAL: function insert_TORNADO_PARTIAL(instruction, code) {
     var tdBody = instruction.tdBody;
     var key = instruction.key;
+    var attrIdx = instruction.attrIdx;
 
     var context = "c";
-    if (instruction.state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
       var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("getPartial") + "('" + key + "', " + context + ", this));\n";
       code.push(tdBody, { fragment: fragment, renderer: renderer });
@@ -57,9 +58,9 @@ var generatorFns = {
   insert_TORNADO_REFERENCE: function insert_TORNADO_REFERENCE(instruction, code) {
     var tdBody = instruction.tdBody;
     var key = instruction.key;
-    var state = instruction.state;
+    var attrIdx = instruction.attrIdx;
 
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
       var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("createTextNode") + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + ")));\n";
       code.push(tdBody, { fragment: fragment, renderer: renderer });
@@ -70,14 +71,14 @@ var generatorFns = {
   },
 
   open_HTML_ELEMENT: function open_HTML_ELEMENT(instruction, code) {
-    var state = instruction.state;
     var tdBody = instruction.tdBody;
     var elCount = instruction.elCount;
+    var attrIdx = instruction.attrIdx;
     var key = instruction.key;
     var namespace = instruction.namespace;
 
     namespace = namespace ? ", '" + namespace + "'" : "";
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      var el" + elCount + " = td." + util.getTdMethodName("createElement") + "('" + key + "'" + namespace + ");\n";
       code.push(tdBody, { fragment: fragment });
     }
@@ -87,11 +88,12 @@ var generatorFns = {
     var parentNodeName = instruction.parentNodeName;
     var elCount = instruction.elCount;
     var tdBody = instruction.tdBody;
+    var attrIdx = instruction.attrIdx;
 
     if (state === STATES.ESCAPABLE_RAW) {
       var fragment = "      el" + (elCount - 1) + ".defaultValue += td." + util.getTdMethodName("nodeToString") + "(el" + elCount + ");\n";
       code.push(tdBody, { fragment: fragment });
-    } else if (state !== STATES.HTML_ATTRIBUTE) {
+    } else if (attrIdx === null) {
       var fragment = "      " + parentNodeName + ".appendChild(el" + elCount + ");\n";
       code.push(tdBody, { fragment: fragment });
     }
@@ -140,8 +142,9 @@ var generatorFns = {
     var tdBody = instruction.tdBody;
     var parentNodeName = instruction.parentNodeName;
     var contents = instruction.contents;
+    var attrIdx = instruction.attrIdx;
 
-    if (instruction.state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + parentNodeName + ".appendChild(td." + util.getTdMethodName("createTextNode") + "('" + contents + "'));\n";
       code.push(tdBody, { fragment: fragment });
     } else {
@@ -177,14 +180,14 @@ var generatorFns = {
   tdBody_exists: function tdBody_exists(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var state = instruction.state;
+    var attrIdx = instruction.attrIdx;
     var key = instruction.key;
     var node = instruction.node;
     var bodyType = instruction.bodyType;
 
     var bodies = node[1].bodies;
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
       var renderer = "      td." + util.getTdMethodName(bodyType) + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), root." + this.getPlaceholderName(instruction) + ", " + bodiesHash + ", c);\n";
       code.push(parentTdBody, { renderer: renderer, fragment: fragment });
@@ -201,13 +204,13 @@ var generatorFns = {
   tdBody_section: function tdBody_section(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var state = instruction.state;
+    var attrIdx = instruction.attrIdx;
     var key = instruction.key;
     var node = instruction.node;
 
     var bodies = node[1].bodies;
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    var isInHtmlAttribute = state === STATES.HTML_ATTRIBUTE;
+    var isInHtmlAttribute = attrIdx !== null;
     var placeholderNode = isInHtmlAttribute ? "null" : "root." + this.getPlaceholderName(instruction);
 
     var output = "td." + util.getTdMethodName("section") + "(td." + util.getTdMethodName("get") + "(c, " + JSON.stringify(key) + "), " + placeholderNode + ", " + bodiesHash + ", c)";
@@ -224,12 +227,12 @@ var generatorFns = {
 
   tdBody_block: function tdBody_block(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
-    var state = instruction.state;
+    var attrIdx = instruction.attrIdx;
     var key = instruction.key;
     var tdBody = instruction.tdBody;
 
     var blockName = key.join(".");
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
       var renderer = "      td." + util.getTdMethodName("replaceNode") + "(root." + this.getPlaceholderName(instruction) + ", td." + util.getTdMethodName("block") + "('" + blockName + "', " + tdBody + ", c, this));\n";
       code.push(parentTdBody, { fragment: fragment, renderer: renderer });
@@ -242,7 +245,7 @@ var generatorFns = {
   tdBody_helper: function tdBody_helper(instruction, code) {
     var parentTdBody = instruction.parentTdBody;
     var tdBody = instruction.tdBody;
-    var state = instruction.state;
+    var attrIdx = instruction.attrIdx;
     var key = instruction.key;
     var node = instruction.node;
 
@@ -250,7 +253,7 @@ var generatorFns = {
     var bodies = node[1].bodies;
     var paramsHash = this.createParamsHash(params);
     var bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       var fragment = "      " + this.createPlaceholder(instruction) + ";\n";
       var renderer = "      td." + util.getTdMethodName("helper") + "('" + key.join(".") + "', root." + this.getPlaceholderName(instruction) + ", c, " + paramsHash + ", " + bodiesHash + ");\n";
       code.push(parentTdBody, { fragment: fragment, renderer: renderer });

--- a/dist/compiler/extensions/generateJS.js
+++ b/dist/compiler/extensions/generateJS.js
@@ -90,7 +90,7 @@ var generatorFns = {
     var tdBody = instruction.tdBody;
     var attrIdx = instruction.attrIdx;
 
-    if (state === STATES.ESCAPABLE_RAW) {
+    if (state.indexOf(STATES.ESCAPABLE_RAW) > -1) {
       var fragment = "      el" + (elCount - 1) + ".defaultValue += td." + util.getTdMethodName("nodeToString") + "(el" + elCount + ");\n";
       code.push(tdBody, { fragment: fragment });
     } else if (attrIdx === null) {

--- a/dist/compiler/utils/FrameStack.js
+++ b/dist/compiler/utils/FrameStack.js
@@ -28,19 +28,22 @@ var FrameStack = function FrameStack() {
   var tdStack = new Stack();
   var elStack = new Stack();
   var phStack = new Stack();
+  var attrStack = new Stack();
 
   this.current = function () {
-    return [tdStack.current(), elStack.current(), phStack.current()];
+    return [tdStack.current(), elStack.current(), phStack.current(), attrStack.current()];
   };
   this.pushTd = function () {
     tdStack.enter();
     elStack.jump();
     phStack.jump();
+    attrStack.jump();
   };
   this.popTd = function () {
     tdStack.leave();
     elStack.drop();
     phStack.drop();
+    attrStack.drop();
   };
   this.pushEl = function () {
     elStack.enter();
@@ -54,10 +57,17 @@ var FrameStack = function FrameStack() {
   this.popPh = function () {
     phStack.leave();
   };
+  this.pushAttr = function () {
+    attrStack.enter();
+  };
+  this.popAttr = function () {
+    attrStack.leave();
+  };
   this.reset = function () {
     tdStack = new Stack();
     elStack = new Stack();
     phStack = new Stack();
+    attrStack = new Stack();
   };
   return this;
 };

--- a/dist/compiler/utils/FrameStack.js
+++ b/dist/compiler/utils/FrameStack.js
@@ -1,28 +1,8 @@
 "use strict";
 
-var Stack = function Stack() {
-  var history = [],
-      memory = [];
-  var count = 0;
-  function current() {
-    return history.length ? history[history.length - 1] : null;
-  }
-  this.current = current;
-  this.enter = function (item) {
-    history.push(item || count++);
-  };
-  this.leave = function () {
-    history.pop();
-  };
-  this.jump = function () {
-    memory.push(history);
-    history = [];
-  };
-  this.drop = function () {
-    history = memory.pop();
-  };
-  return this;
-};
+var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
+
+var Stack = _interopRequire(require("./Stack"));
 
 var FrameStack = function FrameStack() {
   var tdStack = new Stack();

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -6,7 +6,7 @@ var Instruction = function Instruction(action, config) {
   var item = config.item;
   var key = config.key;
   var frameStack = config.frameStack;
-  var state = item.state;
+  var stateStack = config.stateStack;
   var node = item.node;
   var namespace = item.namespace;
 
@@ -53,7 +53,7 @@ var Instruction = function Instruction(action, config) {
     parentNodeName: parentNodeName,
     indexPath: indexPath,
     key: key,
-    state: state,
+    state: stateStack ? stateStack.current() || [] : [],
     node: node,
     namespace: namespace,
     elCount: elIdx,

--- a/dist/compiler/utils/Instruction.js
+++ b/dist/compiler/utils/Instruction.js
@@ -10,14 +10,15 @@ var Instruction = function Instruction(action, config) {
   var node = item.node;
   var namespace = item.namespace;
 
-  var inner = frameStack[0] === null ? 0 : frameStack[0];
-  var outer = frameStack[1] === null ? 0 : frameStack[1];
-  var tdBody = inner && inner[0] !== null ? inner[0] : 0;
-  var parentTdBody = outer && outer[0] !== null ? outer[0] : 0;
-  var elIdx = inner && inner[1] !== null ? inner[1] : 0;
-  var parentNodeIdx = outer && outer[1] !== null ? outer[1] : -1;
-  var placeHolderIdx = inner && inner[2] !== null ? inner[2] : 0;
+  var child = frameStack[0] === null ? 0 : frameStack[0];
+  var parent = frameStack[1] === null ? 0 : frameStack[1];
+  var tdBody = child && child[0] !== null ? child[0] : 0;
+  var parentTdBody = parent && parent[0] !== null ? parent[0] : 0;
+  var elIdx = child && child[1] !== null ? child[1] : 0;
+  var parentNodeIdx = parent && parent[1] !== null ? parent[1] : -1;
+  var placeHolderIdx = child && child[2] !== null ? child[2] : 0;
   var indexPath = "" + placeHolderIdx;
+  var attrIdx = parent && parent[3] !== null ? parent[3] : null;
 
   var _node = _slicedToArray(node, 1);
 
@@ -55,7 +56,8 @@ var Instruction = function Instruction(action, config) {
     state: state,
     node: node,
     namespace: namespace,
-    elCount: elIdx
+    elCount: elIdx,
+    attrIdx: attrIdx
   };
   return instr;
 };

--- a/dist/compiler/utils/Stack.js
+++ b/dist/compiler/utils/Stack.js
@@ -21,6 +21,10 @@ var Stack = function Stack() {
   this.drop = function () {
     history = memory.pop();
   };
+  this.clear = function () {
+    history = [];
+    memory = [];
+  };
   return this;
 };
 

--- a/dist/compiler/utils/Stack.js
+++ b/dist/compiler/utils/Stack.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var Stack = function Stack() {
+  var history = [],
+      memory = [];
+  var count = 0;
+  function current() {
+    return history.length ? history[history.length - 1] : null;
+  }
+  this.current = current;
+  this.enter = function (item) {
+    history.push(item || count++);
+  };
+  this.leave = function () {
+    history.pop();
+  };
+  this.jump = function () {
+    memory.push(history);
+    history = [];
+  };
+  this.drop = function () {
+    history = memory.pop();
+  };
+  return this;
+};
+
+module.exports = Stack;
+//# sourceMappingURL=Stack.js.map

--- a/dist/compiler/visitors/visitorApi.js
+++ b/dist/compiler/visitors/visitorApi.js
@@ -7,22 +7,15 @@ var assign = _interopRequire(require("lodash.assign"));
 var EMPTY_NODE_TYPE = "NIL";
 
 var api = {
-  enterState: function enterState(node, state) {
-    if (node.__enterStates && node.__enterStates.length) {
-      node.__enterStates.push(state);
+  setState: function setState(node, state) {
+    if (node.__states && node.__states.length) {
+      node.__states.push(state);
     } else {
-      node.__enterStates = [state];
+      node.__states = [state];
     }
   },
-  leaveState: function leaveState(node, state) {
-    if (node.__leaveStates && node.__leaveStates.length) {
-      node.__leaveStates.push(state);
-    } else {
-      node.__leaveStates = [state];
-    }
-  },
-  getStates: function getStates(node, direction) {
-    return node["__" + direction + "States"] || [];
+  getStates: function getStates(node) {
+    return node.__states || [];
   },
   rename: function rename(node, newName) {
     node[0] = newName;

--- a/dist/compiler/visitors/visitorApi.js
+++ b/dist/compiler/visitors/visitorApi.js
@@ -7,6 +7,23 @@ var assign = _interopRequire(require("lodash.assign"));
 var EMPTY_NODE_TYPE = "NIL";
 
 var api = {
+  enterState: function enterState(node, state) {
+    if (node.__enterStates && node.__enterStates.length) {
+      node.__enterStates.push(state);
+    } else {
+      node.__enterStates = [state];
+    }
+  },
+  leaveState: function leaveState(node, state) {
+    if (node.__leaveStates && node.__leaveStates.length) {
+      node.__leaveStates.push(state);
+    } else {
+      node.__leaveStates = [state];
+    }
+  },
+  getStates: function getStates(node, direction) {
+    return node["__" + direction + "States"] || [];
+  },
   rename: function rename(node, newName) {
     node[0] = newName;
   },

--- a/src/compiler/context.js
+++ b/src/compiler/context.js
@@ -30,32 +30,12 @@ if (!Object.assign) {
   });
 }
 
-const STATES = {
-  OUTER_SPACE: 'OUTER_SPACE',
-  HTML_TAG: 'HTML_TAG',
-  HTML_BODY: 'HTML_BODY',
-  HTML_ATTRIBUTE: 'HTML_ATTRIBUTE',
-  ESCAPABLE_RAW: 'ESCAPABLE_RAW',
-  TORNADO_TAG: 'TORNADO_TAG',
-  TORNADO_BODY: 'TORNADO_BODY'
-};
-
 let Context = function(results) {
   let nodeStack = [{}];
-  const defaultState = STATES.OUTER_SPACE;
 
   let context = {
-    state: defaultState,
     pushInstruction(instruction) {
       results.instructions.push(instruction);
-    },
-    getCurrentState() {
-      let state = STATES[this.stack.peek('nodeType')] || this.stack.peek('state');
-      if (!state) {
-        return STATES.OUTER_SPACE;
-      } else {
-        return state;
-      }
     },
     getNamespaceFromNode(node) {
       let nodeInfo = node[1].tag_info;
@@ -78,16 +58,10 @@ let Context = function(results) {
         if (nodeType === 'HTML_ELEMENT' || nodeType === 'HTML_ATTRIBUTE') {
           namespace = this.getCurrentNamespace(namespace);
         }
-        let state = this.getCurrentState();
 
-        if (node[1].escapableRaw) {
-          state = STATES.ESCAPABLE_RAW;
-        }
         let stackItem = {
           node,
           nodeType,
-          state,
-          previousState: this.stack.peek('state'),
           namespace
         };
         nodeStack.push(stackItem);

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -12,106 +12,108 @@ let instructionDefs = {
   },
   TORNADO_PARTIAL(node, ctx, frameStack) {
     // we are not creating a new tdBody for partials
-    let inner, outer;
+    let child, parent;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx}));
   },
   TORNADO_BODY: {
     enter(node, ctx, frameStack) {
-      let outer = frameStack.current();
+      let parent = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.pushTd();
         frameStack.pushPh();
       }
-      let inner = frameStack.current();
+      let child = frameStack.current();
       return {
         type: 'open',
-        options: {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}
+        options: {key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx}
       };
     },
     leave(node, ctx, frameStack) {
-      let inner = frameStack.current();
+      let child = frameStack.current();
       if (node[1].body && node[1].body.length) {
         frameStack.popPh();
         frameStack.popTd();
       }
-      let outer = frameStack.current();
+      let parent = frameStack.current();
       return {
         type: 'close',
-        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
+        options: {item: node.stackItem, frameStack: [child, parent], ctx}
       };
     }
   },
   TORNADO_REFERENCE(node, ctx, frameStack) {
-    let inner, outer;
+    let child, parent;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [inner, outer], ctx}));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction('insert', {key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx}));
   },
   TORNADO_COMMENT(node, ctx, frameStack) {
-    let inner, outer;
+    let child, parent;
     frameStack.pushPh();
-    inner = frameStack.current();
+    child = frameStack.current();
     frameStack.popPh();
-    outer = frameStack.current();
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
+    parent = frameStack.current();
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [child, parent], ctx}));
   },
   HTML_ELEMENT: {
     enter(node, ctx, frameStack) {
-      let outer = frameStack.current();
+      let parent = frameStack.current();
       frameStack.pushEl();
-      let inner = frameStack.current();
+      let child = frameStack.current();
       return {
         type: 'open',
-        options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: [inner, outer], ctx}
+        options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx}
       };
     },
     leave(node, ctx, frameStack){
       let item = node.stackItem;
       item.state = item.previousState;
-      let inner = frameStack.current();
+      let child = frameStack.current();
       frameStack.popEl();
-      let outer = frameStack.current();
+      let parent = frameStack.current();
       return {
         type: 'close',
-        options: {item, frameStack: [inner, outer], ctx}
+        options: {item, frameStack: [child, parent], ctx}
       };
     }
   },
   HTML_ATTRIBUTE: {
     enter(node, ctx, frameStack) {
-      let outer = frameStack.current();
+      let parent = frameStack.current();
+      frameStack.pushAttr();
       frameStack.pushPh();
-      let inner = frameStack.current();
+      let child = frameStack.current();
       return {
         type: 'open',
-        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
+        options: {item: node.stackItem, frameStack: [child, parent], ctx}
       };
     },
     leave(node, ctx, frameStack) {
-      let inner = frameStack.current();
+      let child = frameStack.current();
       frameStack.popPh();
-      let outer = frameStack.current();
+      frameStack.popAttr();
+      let parent = frameStack.current();
       return {
         type: 'close',
-        options: {item: node.stackItem, frameStack: [inner, outer], ctx}
+        options: {item: node.stackItem, frameStack: [child, parent], ctx}
       };
     }
   },
   HTML_COMMENT(node, ctx, frameStack) {
-    let inner = frameStack.current(),
-        outer = inner;
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
+    let child = frameStack.current(),
+        parent = child;
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [child, parent], ctx}));
   },
   PLAIN_TEXT(node, ctx, frameStack) {
-    let inner = frameStack.current(),
-        outer = inner;
-    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [inner, outer], ctx}));
+    let child = frameStack.current(),
+        parent = child;
+    ctx.pushInstruction(new Instruction('insert', {item: node.stackItem, frameStack: [child, parent], ctx}));
   }
 };
 

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -3,11 +3,25 @@
 import visitor from '../visitors/visitor';
 import Instruction from '../utils/Instruction';
 import FrameStack from '../utils/FrameStack';
+import Stack from '../utils/Stack';
 
 function noop() {}
 
+
+function enterAll(stateStack, states) {
+  states.forEach(function(s) {
+    stateStack.enter(s);
+  });
+}
+function leaveAll(stateStack, states) {
+  states.forEach(function(s) {
+    stateStack.leave(s);
+  });
+}
+
 let instructionDefs = {
-  TEMPLATE(node, ctx, frameStack) {
+  TEMPLATE(node, ctx, frameStack, stateStack) {
+    stateStack = new Stack();
     frameStack.reset();
   },
   TORNADO_PARTIAL(node, ctx, frameStack) {
@@ -145,9 +159,10 @@ let buildInstructions = {
   },
   generateInstructions() {
     let frameStack = new FrameStack();
+    let stateStack = new Stack();
     let walker = visitor.build(this.instructionDefs);
     return function(ast, options) {
-      return walker(ast, options.context, frameStack);
+      return walker(ast, options.context, frameStack, stateStack);
     };
   }
 };

--- a/src/compiler/extensions/buildInstructions.js
+++ b/src/compiler/extensions/buildInstructions.js
@@ -45,7 +45,7 @@ let instructionDefs = {
         type: 'open',
         options: {key: node[1].key, item: node.stackItem, frameStack: [child, parent], ctx, stateStack}
       };
-      enterAll(this.getStates(node, 'enter'), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave(node, ctx, frameStack, stateStack) {
@@ -55,7 +55,7 @@ let instructionDefs = {
         frameStack.popTd();
       }
       let parent = frameStack.current();
-      leaveAll(this.getStates(node, 'leave'), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       let out = {
         type: 'close',
         options: {item: node.stackItem, frameStack: [child, parent], ctx, stateStack}
@@ -88,7 +88,7 @@ let instructionDefs = {
         type: 'open',
         options: {key: node[1].tag_info.key, item: node.stackItem, frameStack: [child, parent], ctx, stateStack}
       };
-      enterAll(this.getStates(node, 'enter'), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave(node, ctx, frameStack, stateStack){
@@ -97,7 +97,7 @@ let instructionDefs = {
       let child = frameStack.current();
       frameStack.popEl();
       let parent = frameStack.current();
-      leaveAll(this.getStates(node, 'leave'), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       let out = {
         type: 'close',
         options: {item, frameStack: [child, parent], ctx, stateStack}
@@ -115,7 +115,7 @@ let instructionDefs = {
         type: 'open',
         options: {item: node.stackItem, frameStack: [child, parent], ctx, stateStack}
       };
-      enterAll(this.getStates(node, 'enter'), stateStack);
+      enterAll(this.getStates(node), stateStack);
       return out;
     },
     leave(node, ctx, frameStack, stateStack) {
@@ -123,7 +123,7 @@ let instructionDefs = {
       frameStack.popPh();
       frameStack.popAttr();
       let parent = frameStack.current();
-      leaveAll(this.getStates(node, 'leave'), stateStack);
+      leaveAll(this.getStates(node), stateStack);
       let out = {
         type: 'close',
         options: {item: node.stackItem, frameStack: [child, parent], ctx, stateStack}

--- a/src/compiler/extensions/debugger.js
+++ b/src/compiler/extensions/debugger.js
@@ -19,11 +19,11 @@ let debuggerExtension = {
   instructions: {
     TORNADO_DEBUGGER: {
       enter(node, ctx, frameStack) {
-        let inner = frameStack.current(),
-            outer = inner;
+        let child = frameStack.current(),
+            parent = child;
         return {
           type: 'insert',
-          options: {key: node[1].key, frameStack: [inner, outer], item: node.stackItem, ctx}
+          options: {key: node[1].key, frameStack: [child, parent], item: node.stackItem, ctx}
         };
       }
     }

--- a/src/compiler/extensions/escapableRaw.js
+++ b/src/compiler/extensions/escapableRaw.js
@@ -1,6 +1,6 @@
 'use strict';
 import visitor from '../visitors/visitor';
-import {STATES} form '../utils/builder';
+import {STATES} from '../utils/builder';
 
 const escapableRawEls = ['textarea', 'title'];
 let generatedWalker = visitor.build({
@@ -8,13 +8,13 @@ let generatedWalker = visitor.build({
     enter(node) {
       let key = node[1].tag_info.key;
       if (escapableRawEls.indexOf(key) > -1) {
-        this.addState(node, STATES.ESCAPABLE_RAW);
+        this.enterState(node, STATES.ESCAPABLE_RAW);
       }
     },
     leave(node) {
       let key = node[1].tag_info.key;
       if (escapableRawEls.indexOf(key) > -1) {
-        this.removeState(node, STATES.ESCAPABLE_RAW);
+        this.leaveState(node, STATES.ESCAPABLE_RAW);
       }
     }
   }

--- a/src/compiler/extensions/escapableRaw.js
+++ b/src/compiler/extensions/escapableRaw.js
@@ -1,12 +1,21 @@
 'use strict';
 import visitor from '../visitors/visitor';
+import {STATES} form '../utils/builder';
 
 const escapableRawEls = ['textarea', 'title'];
 let generatedWalker = visitor.build({
-  HTML_ELEMENT(node) {
-    let key = node[1].tag_info.key;
-    if (escapableRawEls.indexOf(key) > -1) {
-      node[1].escapableRaw = true;
+  HTML_ELEMENT: {
+    enter(node) {
+      let key = node[1].tag_info.key;
+      if (escapableRawEls.indexOf(key) > -1) {
+        this.addState(node, STATES.ESCAPABLE_RAW);
+      }
+    },
+    leave(node) {
+      let key = node[1].tag_info.key;
+      if (escapableRawEls.indexOf(key) > -1) {
+        this.removeState(node, STATES.ESCAPABLE_RAW);
+      }
     }
   }
 });

--- a/src/compiler/extensions/escapableRaw.js
+++ b/src/compiler/extensions/escapableRaw.js
@@ -4,18 +4,10 @@ import {STATES} from '../utils/builder';
 
 const escapableRawEls = ['textarea', 'title'];
 let generatedWalker = visitor.build({
-  HTML_ELEMENT: {
-    enter(node) {
-      let key = node[1].tag_info.key;
-      if (escapableRawEls.indexOf(key) > -1) {
-        this.enterState(node, STATES.ESCAPABLE_RAW);
-      }
-    },
-    leave(node) {
-      let key = node[1].tag_info.key;
-      if (escapableRawEls.indexOf(key) > -1) {
-        this.leaveState(node, STATES.ESCAPABLE_RAW);
-      }
+  HTML_ELEMENT(node) {
+    let key = node[1].tag_info.key;
+    if (escapableRawEls.indexOf(key) > -1) {
+      this.setState(node, STATES.ESCAPABLE_RAW);
     }
   }
 });

--- a/src/compiler/extensions/generateJS.js
+++ b/src/compiler/extensions/generateJS.js
@@ -62,7 +62,7 @@ let generatorFns = {
   },
   close_HTML_ELEMENT(instruction, code) {
     let {state, parentNodeName, elCount, tdBody, attrIdx} = instruction;
-    if (state === STATES.ESCAPABLE_RAW) {
+    if (state.indexOf(STATES.ESCAPABLE_RAW) > -1) {
       let fragment = `      el${elCount - 1}.defaultValue += td.${util.getTdMethodName('nodeToString')}(el${elCount});\n`;
       code.push(tdBody, {fragment});
     } else if (attrIdx === null) {

--- a/src/compiler/extensions/generateJS.js
+++ b/src/compiler/extensions/generateJS.js
@@ -9,9 +9,9 @@ const noop = function() {};
 
 let generatorFns = {
   insert_TORNADO_PARTIAL(instruction, code) {
-    let {tdBody, key} = instruction;
+    let {tdBody, key, attrIdx} = instruction;
     let context = 'c';
-    if (instruction.state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       let fragment = `      ${this.createPlaceholder(instruction)};\n`;
       let renderer = `      td.${util.getTdMethodName('replaceNode')}(root.${this.getPlaceholderName(instruction)}, td.${util.getTdMethodName('getPartial')}('${key}', ${context}, this));\n`;
       code.push(tdBody, {fragment, renderer});
@@ -41,8 +41,8 @@ let generatorFns = {
     }
   },
   insert_TORNADO_REFERENCE(instruction, code) {
-    let {tdBody, key, state} = instruction;
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    let {tdBody, key, attrIdx} = instruction;
+    if (attrIdx === null) {
       let fragment = `      ${this.createPlaceholder(instruction)};\n`;
       let renderer = `      td.${util.getTdMethodName('replaceNode')}(root.${this.getPlaceholderName(instruction)}, td.${util.getTdMethodName('createTextNode')}(td.${util.getTdMethodName('get')}(c, ${JSON.stringify(key)})));\n`;
       code.push(tdBody, {fragment, renderer});
@@ -53,19 +53,19 @@ let generatorFns = {
   },
 
   open_HTML_ELEMENT(instruction, code) {
-    let {state, tdBody, elCount, key, namespace} = instruction;
+    let {tdBody, elCount, attrIdx, key, namespace} = instruction;
     namespace = namespace ? `, '${namespace}'` : '';
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       let fragment = `      var el${elCount} = td.${util.getTdMethodName('createElement')}('${key}'${namespace});\n`;
       code.push(tdBody, {fragment});
     }
   },
   close_HTML_ELEMENT(instruction, code) {
-    let {state, parentNodeName, elCount, tdBody} = instruction;
+    let {state, parentNodeName, elCount, tdBody, attrIdx} = instruction;
     if (state === STATES.ESCAPABLE_RAW) {
       let fragment = `      el${elCount - 1}.defaultValue += td.${util.getTdMethodName('nodeToString')}(el${elCount});\n`;
       code.push(tdBody, {fragment});
-    } else if (state !== STATES.HTML_ATTRIBUTE) {
+    } else if (attrIdx === null) {
       let fragment = `      ${parentNodeName}.appendChild(el${elCount});\n`;
       code.push(tdBody, {fragment});
     }
@@ -102,8 +102,8 @@ let generatorFns = {
     code.push(tdBody, {fragment});
   },
   insert_PLAIN_TEXT(instruction, code) {
-    let {tdBody, parentNodeName, contents} = instruction;
-    if (instruction.state !== STATES.HTML_ATTRIBUTE) {
+    let {tdBody, parentNodeName, contents, attrIdx} = instruction;
+    if (attrIdx === null) {
       let fragment = `      ${parentNodeName}.appendChild(td.${util.getTdMethodName('createTextNode')}('${contents}'));\n`;
       code.push(tdBody, {fragment});
     } else {
@@ -144,10 +144,10 @@ let generatorFns = {
   },
 
   tdBody_exists(instruction, code) {
-    let {parentTdBody, tdBody, state, key, node, bodyType} = instruction;
+    let {parentTdBody, tdBody, attrIdx, key, node, bodyType} = instruction;
     let bodies = node[1].bodies;
     let bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       let fragment = `      ${this.createPlaceholder(instruction)};\n`;
       let renderer = `      td.${util.getTdMethodName(bodyType)}(td.${util.getTdMethodName('get')}(c, ${JSON.stringify(key)}), root.${this.getPlaceholderName(instruction)}, ${bodiesHash}, c);\n`;
       code.push((parentTdBody), {renderer, fragment});
@@ -162,10 +162,10 @@ let generatorFns = {
   },
 
   tdBody_section(instruction, code) {
-    let {parentTdBody, tdBody, state, key, node} = instruction;
+    let {parentTdBody, tdBody, attrIdx, key, node} = instruction;
     let bodies = node[1].bodies;
     let bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    let isInHtmlAttribute = (state === STATES.HTML_ATTRIBUTE);
+    let isInHtmlAttribute = (attrIdx !== null);
     let placeholderNode = isInHtmlAttribute ? 'null' : `root.${this.getPlaceholderName(instruction)}`;
 
     let output = `td.${util.getTdMethodName('section')}(td.${util.getTdMethodName('get')}(c, ${JSON.stringify(key)}), ${placeholderNode}, ${bodiesHash}, c)`;
@@ -181,9 +181,9 @@ let generatorFns = {
   },
 
   tdBody_block(instruction, code) {
-    let {parentTdBody, state, key, tdBody} = instruction;
+    let {parentTdBody, attrIdx, key, tdBody} = instruction;
     let blockName = key.join('.');
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       let fragment = `      ${this.createPlaceholder(instruction)};\n`;
       let renderer = `      td.${util.getTdMethodName('replaceNode')}(root.${this.getPlaceholderName(instruction)}, td.${util.getTdMethodName('block')}('${blockName}', ${tdBody}, c, this));\n`;
       code.push(parentTdBody, {fragment, renderer});
@@ -194,12 +194,12 @@ let generatorFns = {
   },
 
   tdBody_helper(instruction, code) {
-    let {parentTdBody, tdBody, state, key, node} = instruction;
+    let {parentTdBody, tdBody, attrIdx, key, node} = instruction;
     let params = node[1].params;
     let bodies = node[1].bodies;
     let paramsHash = this.createParamsHash(params);
     let bodiesHash = this.createBodiesHash(tdBody, bodies, node[1].body);
-    if (state !== STATES.HTML_ATTRIBUTE) {
+    if (attrIdx === null) {
       let fragment = `      ${this.createPlaceholder(instruction)};\n`;
       let renderer = `      td.${util.getTdMethodName('helper')}('${key.join('.')}', root.${this.getPlaceholderName(instruction)}, c, ${paramsHash}, ${bodiesHash});\n`;
       code.push(parentTdBody, {fragment, renderer});

--- a/src/compiler/utils/FrameStack.js
+++ b/src/compiler/utils/FrameStack.js
@@ -26,19 +26,22 @@ let FrameStack = function() {
   let tdStack = new Stack();
   let elStack = new Stack();
   let phStack = new Stack();
+  let attrStack = new Stack();
 
   this.current = function() {
-    return [tdStack.current(), elStack.current(), phStack.current()];
+    return [tdStack.current(), elStack.current(), phStack.current(), attrStack.current()];
   };
   this.pushTd = function() {
     tdStack.enter();
     elStack.jump();
     phStack.jump();
+    attrStack.jump();
   };
   this.popTd = function() {
     tdStack.leave();
     elStack.drop();
     phStack.drop();
+    attrStack.drop();
   };
   this.pushEl = function() {
     elStack.enter();
@@ -52,10 +55,17 @@ let FrameStack = function() {
   this.popPh = function() {
     phStack.leave();
   };
+  this.pushAttr = function() {
+    attrStack.enter();
+  };
+  this.popAttr = function() {
+    attrStack.leave();
+  };
   this.reset = function() {
     tdStack = new Stack();
     elStack = new Stack();
     phStack = new Stack();
+    attrStack = new Stack();
   };
   return this;
 };

--- a/src/compiler/utils/FrameStack.js
+++ b/src/compiler/utils/FrameStack.js
@@ -1,26 +1,4 @@
-let Stack = function() {
-  let history = [],
-      memory = [];
-  let count = 0;
-  function current() {
-    return history.length ? history[history.length - 1] : null;
-  }
-  this.current = current;
-  this.enter = function(item) {
-    history.push(item || count++);
-  };
-  this.leave = function() {
-    history.pop();
-  };
-  this.jump = function() {
-    memory.push(history);
-    history = [];
-  };
-  this.drop = function() {
-    history = memory.pop();
-  };
-  return this;
-};
+import Stack from './Stack';
 
 let FrameStack = function() {
   let tdStack = new Stack();
@@ -71,4 +49,4 @@ let FrameStack = function() {
 };
 
 
-module.exports = FrameStack;
+export default FrameStack;

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,6 +1,6 @@
 let Instruction = function(action, config) {
-  let {item, key, frameStack} = config;
-  let {state, node, namespace} = item;
+  let {item, key, frameStack, stateStack} = config;
+  let {node, namespace} = item;
   let child = frameStack[0] === null ? 0 : frameStack[0];
   let parent = frameStack[1] === null ? 0 : frameStack[1];
   let tdBody = ( child && child[0] !== null ) ? child[0] : 0;
@@ -39,7 +39,7 @@ let Instruction = function(action, config) {
     parentNodeName: parentNodeName,
     indexPath,
     key,
-    state,
+    state: stateStack ? stateStack.current() || [] : [],
     node,
     namespace,
     elCount: elIdx,

--- a/src/compiler/utils/Instruction.js
+++ b/src/compiler/utils/Instruction.js
@@ -1,14 +1,15 @@
 let Instruction = function(action, config) {
   let {item, key, frameStack} = config;
   let {state, node, namespace} = item;
-  let inner = frameStack[0] === null ? 0 : frameStack[0];
-  let outer = frameStack[1] === null ? 0 : frameStack[1];
-  let tdBody = ( inner && inner[0] !== null ) ? inner[0] : 0;
-  let parentTdBody = ( outer && outer[0] !== null ) ? outer[0] : 0;
-  let elIdx = ( inner && inner[1] !== null ) ? inner[1] : 0;
-  let parentNodeIdx = ( outer && outer[1] !== null ) ? outer[1] : -1;
-  let placeHolderIdx = (inner && inner[2] !== null) ? inner[2] : 0;
+  let child = frameStack[0] === null ? 0 : frameStack[0];
+  let parent = frameStack[1] === null ? 0 : frameStack[1];
+  let tdBody = ( child && child[0] !== null ) ? child[0] : 0;
+  let parentTdBody = ( parent && parent[0] !== null ) ? parent[0] : 0;
+  let elIdx = ( child && child[1] !== null ) ? child[1] : 0;
+  let parentNodeIdx = ( parent && parent[1] !== null ) ? parent[1] : -1;
+  let placeHolderIdx = (child && child[2] !== null) ? child[2] : 0;
   let indexPath = '' + placeHolderIdx;
+  let attrIdx = ( parent && parent[3] !== null ) ? parent[3] : null;
 
   let [nodeType] = node;
   let contents;
@@ -41,7 +42,8 @@ let Instruction = function(action, config) {
     state,
     node,
     namespace,
-    elCount: elIdx
+    elCount: elIdx,
+    attrIdx
   };
   return instr;
 };

--- a/src/compiler/utils/Stack.js
+++ b/src/compiler/utils/Stack.js
@@ -19,6 +19,10 @@ let Stack = function() {
   this.drop = function() {
     history = memory.pop();
   };
+  this.clear = function() {
+    history = [];
+    memory = [];
+  };
   return this;
 };
 

--- a/src/compiler/utils/Stack.js
+++ b/src/compiler/utils/Stack.js
@@ -1,0 +1,25 @@
+let Stack = function() {
+  let history = [],
+      memory = [];
+  let count = 0;
+  function current() {
+    return history.length ? history[history.length - 1] : null;
+  }
+  this.current = current;
+  this.enter = function(item) {
+    history.push(item || count++);
+  };
+  this.leave = function() {
+    history.pop();
+  };
+  this.jump = function() {
+    memory.push(history);
+    history = [];
+  };
+  this.drop = function() {
+    history = memory.pop();
+  };
+  return this;
+};
+
+export default Stack;

--- a/src/compiler/visitors/visitorApi.js
+++ b/src/compiler/visitors/visitorApi.js
@@ -2,21 +2,22 @@ import assign from 'lodash.assign';
 let EMPTY_NODE_TYPE = 'NIL';
 
 let api = {
-  addState: function(node, state) {
-    node.__states = node.__states && node.__states.length ? node.__states.push(state) : node.__states = [state];
-  },
-  removeState: function(node, state) {
-    let idx;
-    if (node.__states && node.__states.length) {
-      idx = node.__states.indexOf(state);
-      if (idx > -1) {
-        // remove the found state
-        node.__states.splice(idx, 1);
-      }
+  enterState: function(node, state) {
+    if (node.__enterStates && node.__enterStates.length) {
+      node.__enterStates.push(state);
+    } else {
+      node.__enterStates = [state];
     }
   },
-  getState: function(node) {
-    return node.__states || [];
+  leaveState: function(node, state) {
+    if (node.__leaveStates && node.__leaveStates.length) {
+      node.__leaveStates.push(state);
+    } else {
+      node.__leaveStates = [state];
+    }
+  },
+  getStates: function(node, direction) {
+    return node['__' + direction + 'States'] || [];
   },
   rename: function(node, newName) {
     node[0] = newName;

--- a/src/compiler/visitors/visitorApi.js
+++ b/src/compiler/visitors/visitorApi.js
@@ -2,22 +2,15 @@ import assign from 'lodash.assign';
 let EMPTY_NODE_TYPE = 'NIL';
 
 let api = {
-  enterState: function(node, state) {
-    if (node.__enterStates && node.__enterStates.length) {
-      node.__enterStates.push(state);
+  setState: function(node, state) {
+    if (node.__states && node.__states.length) {
+      node.__states.push(state);
     } else {
-      node.__enterStates = [state];
+      node.__states = [state];
     }
   },
-  leaveState: function(node, state) {
-    if (node.__leaveStates && node.__leaveStates.length) {
-      node.__leaveStates.push(state);
-    } else {
-      node.__leaveStates = [state];
-    }
-  },
-  getStates: function(node, direction) {
-    return node['__' + direction + 'States'] || [];
+  getStates: function(node) {
+    return node.__states || [];
   },
   rename: function(node, newName) {
     node[0] = newName;

--- a/src/compiler/visitors/visitorApi.js
+++ b/src/compiler/visitors/visitorApi.js
@@ -2,6 +2,22 @@ import assign from 'lodash.assign';
 let EMPTY_NODE_TYPE = 'NIL';
 
 let api = {
+  addState: function(node, state) {
+    node.__states = node.__states && node.__states.length ? node.__states.push(state) : node.__states = [state];
+  },
+  removeState: function(node, state) {
+    let idx;
+    if (node.__states && node.__states.length) {
+      idx = node.__states.indexOf(state);
+      if (idx > -1) {
+        // remove the found state
+        node.__states.splice(idx, 1);
+      }
+    }
+  },
+  getState: function(node) {
+    return node.__states || [];
+  },
   rename: function(node, newName) {
     node[0] = newName;
   },


### PR DESCRIPTION
i'm closing #137 in favor of this.

I've moved the logic around states into 
1. a visitorApi accessible from `this`
2. a Stack in the build instructions that reads from the states set on the `node` and keeps track of the stack of states.

Questions/TBD:
- instead of `attrIdx` on the framestack, we could have `HTML_ATTRIBUTE` on the stateStack instead.
