### PR TITLE
Text in textareas is plaintext

### DIFF
--- a/test/acceptance/html.js
+++ b/test/acceptance/html.js
@@ -79,6 +79,14 @@ let suite = {
       expectedHTML: '<textarea>&lt;script&gt;alert("Hacked!");&lt;/script&gt;</textarea>'
     },
     {
+      description: 'Textarea with HTML inside and tornado body inside',
+      template: '<textarea><script>{?badGuys}alert("Hacked!");{/badGuys}</script></textarea>',
+      context: {
+        badGuys: true
+      },
+      expectedHTML: '<textarea>&lt;script&gt;alert("Hacked!");&lt;/script&gt;</textarea>'
+    },
+    {
       description: 'SVG created with a namespace',
       template: `<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="red"/></svg>`,
       context: {},

--- a/test/sandbox/index.html
+++ b/test/sandbox/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="input">
-      <textarea id="template" placeholder="Template goes here">{#hello}{@debugger/}{/hello}</textarea>
+      <textarea id="template" placeholder="Template goes here"><textarea><div>{?hello}yes{/hello}</div></textarea&gt;</textarea>
       <textarea id="context" placeholder="Context goes here">{
   hello: ['yes']
 }</textarea>

--- a/test/sandbox/sandbox.js
+++ b/test/sandbox/sandbox.js
@@ -20,9 +20,9 @@ button.addEventListener('click', function() {
   var t = templateTextArea.value;
   var c = contextTextArea.value;
   var ast = parser.parse(t);
-  astContainer.innerHTML = JSON.stringify(ast, null, 2);
+  astContainer.textContent = JSON.stringify(ast, null, 2);
   var compiled = compiler.compile(ast, 'test');
-  compiledContainer.innerHTML = compiled;
+  compiledContainer.textContent = compiled;
   var tl = eval(compiled);
   var data = {};
   eval('data = ' + c + ';');


### PR DESCRIPTION
Fixes #141. Text in textareas is parsed as a plainsrting with the
exception of tornado elements, which are still parsed. There is still
the problem with an HTML element inside of a tornado body inside of a
text area. I think this solution may be the right path for that bug as
well.
